### PR TITLE
#16 一括反映UIと反映APIを追加

### DIFF
--- a/src/app/_components/bulk/bulk-sync-section.tsx
+++ b/src/app/_components/bulk/bulk-sync-section.tsx
@@ -1,0 +1,242 @@
+"use client"
+
+import { useMemo, useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Textarea } from "@/components/ui/textarea"
+import { parsePayloadJson } from "@/lib/bulk-sync/ui-utils"
+
+const MAX_ERRORS = 200
+const MAX_ISSUES = 200
+
+type DiffItem = {
+  entity: string
+  operation: "create" | "update" | "delete"
+  key: { id?: string; naturalKey: string }
+  issues: { message: string }[]
+}
+
+type DiffResponse = {
+  summary: { total: number; create: number; update: number; delete: number }
+  items: DiffItem[]
+}
+
+type ApplyResponse = {
+  jobId: string
+  status: string
+  summary: { total: number; create: number; update: number; delete: number; success: number; failed: number }
+  errors: { entity: string; rowIndex?: number; message: string; code: string }[]
+}
+
+export function BulkSyncSection() {
+  const [payloadInput, setPayloadInput] = useState("")
+  const [diffResult, setDiffResult] = useState<DiffResponse | null>(null)
+  const [applyResult, setApplyResult] = useState<ApplyResponse | null>(null)
+  const [busy, setBusy] = useState<"diff" | "apply" | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [dryRun, setDryRun] = useState(false)
+  const [recordAuditLog, setRecordAuditLog] = useState(true)
+
+  const parsedPayload = useMemo(() => parsePayloadJson(payloadInput), [payloadInput])
+
+  const issueItems = useMemo(() => {
+    if (!diffResult) return []
+    return diffResult.items.filter((item) => item.issues.length > 0).slice(0, MAX_ISSUES)
+  }, [diffResult])
+
+  const handleDiff = async () => {
+    setErrorMessage(null)
+    setApplyResult(null)
+
+    if (!parsedPayload.payload) {
+      setErrorMessage(parsedPayload.error ?? "JSON を確認してください")
+      return
+    }
+
+    setBusy("diff")
+    try {
+      const response = await fetch("/api/bulk-sync/diff", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ payload: parsedPayload.payload, options: { includeDetails: true } }),
+      })
+
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({}))
+        throw new Error(error.error ?? "差分取得に失敗しました")
+      }
+
+      const data = (await response.json()) as DiffResponse
+      setDiffResult(data)
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "差分取得に失敗しました")
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const handleApply = async () => {
+    setErrorMessage(null)
+
+    if (!parsedPayload.payload) {
+      setErrorMessage(parsedPayload.error ?? "JSON を確認してください")
+      return
+    }
+
+    setBusy("apply")
+    try {
+      const response = await fetch("/api/bulk-sync/apply", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ payload: parsedPayload.payload, options: { dryRun, recordAuditLog } }),
+      })
+
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({}))
+        throw new Error(error.error ?? "反映に失敗しました")
+      }
+
+      const data = (await response.json()) as ApplyResponse
+      setApplyResult(data)
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "反映に失敗しました")
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const statusText = busy === "diff" ? "差分を確認中..." : busy === "apply" ? "反映中..." : "待機中"
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>一括反映</CardTitle>
+        <CardDescription>スプレッドシートから生成した JSON を投入して差分と反映結果を確認します。</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="bulk-sync-payload">投入 JSON</Label>
+            <Badge variant={busy ? "default" : "secondary"}>{statusText}</Badge>
+          </div>
+          <Textarea
+            id="bulk-sync-payload"
+            rows={10}
+            placeholder='{"materials":[],"products":[]}'
+            value={payloadInput}
+            onChange={(event) => setPayloadInput(event.target.value)}
+          />
+          <p className="text-xs text-muted-foreground">`docs/spreadsheet-spec.md` と `docs/api/bulk-sync.md` の定義に準拠してください。</p>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2 rounded-lg border border-dashed p-3">
+            <p className="text-sm font-medium">実行オプション</p>
+            <label className="flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={dryRun} onChange={(event) => setDryRun(event.target.checked)} />
+              Dry Run（反映せず検証のみ）
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={recordAuditLog}
+                onChange={(event) => setRecordAuditLog(event.target.checked)}
+              />
+              監査ログを記録する
+            </label>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Button onClick={handleDiff} disabled={busy !== null}>
+              差分を確認
+            </Button>
+            <Button onClick={handleApply} disabled={busy !== null} variant="default">
+              一括反映を実行
+            </Button>
+            {errorMessage && <p className="text-sm text-destructive">{errorMessage}</p>}
+          </div>
+        </div>
+
+        {diffResult && (
+          <div className="space-y-3">
+            <div className="flex flex-wrap gap-3">
+              <Badge variant="secondary">差分合計: {diffResult.summary.total}</Badge>
+              <Badge variant="outline">新規: {diffResult.summary.create}</Badge>
+              <Badge variant="outline">更新: {diffResult.summary.update}</Badge>
+              <Badge variant="outline">削除: {diffResult.summary.delete}</Badge>
+              <Badge variant={issueItems.length > 0 ? "destructive" : "secondary"}>
+                指摘件数: {issueItems.length}
+              </Badge>
+            </div>
+            {issueItems.length > 0 && (
+              <div className="rounded-lg border p-3">
+                <p className="text-sm font-medium">差分検証の指摘（最大 {MAX_ISSUES} 件）</p>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>対象</TableHead>
+                      <TableHead>操作</TableHead>
+                      <TableHead>メッセージ</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {issueItems.map((item, index) => (
+                      <TableRow key={`${item.entity}-${item.operation}-${index}`}>
+                        <TableCell className="text-xs">{item.entity}</TableCell>
+                        <TableCell className="text-xs">{item.operation}</TableCell>
+                        <TableCell className="text-xs">{item.issues.map((issue) => issue.message).join(" / ")}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </div>
+        )}
+
+        {applyResult && (
+          <div className="space-y-3">
+            <div className="flex flex-wrap gap-3">
+              <Badge variant="secondary">反映合計: {applyResult.summary.total}</Badge>
+              <Badge variant="outline">成功: {applyResult.summary.success}</Badge>
+              <Badge variant={applyResult.summary.failed > 0 ? "destructive" : "secondary"}>
+                失敗: {applyResult.summary.failed}
+              </Badge>
+              <Badge variant="outline">新規: {applyResult.summary.create}</Badge>
+              <Badge variant="outline">更新: {applyResult.summary.update}</Badge>
+              <Badge variant="outline">削除: {applyResult.summary.delete}</Badge>
+            </div>
+            {applyResult.errors.length > 0 && (
+              <div className="rounded-lg border p-3">
+                <p className="text-sm font-medium">エラー詳細（最大 {MAX_ERRORS} 件）</p>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>対象</TableHead>
+                      <TableHead>行</TableHead>
+                      <TableHead>コード</TableHead>
+                      <TableHead>メッセージ</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {applyResult.errors.slice(0, MAX_ERRORS).map((error, index) => (
+                      <TableRow key={`${error.entity}-${error.rowIndex ?? "-"}-${index}`}>
+                        <TableCell className="text-xs">{error.entity}</TableCell>
+                        <TableCell className="text-xs">{error.rowIndex ?? "-"}</TableCell>
+                        <TableCell className="text-xs">{error.code}</TableCell>
+                        <TableCell className="text-xs">{error.message}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/_components/bulk/bulk-tab.tsx
+++ b/src/app/_components/bulk/bulk-tab.tsx
@@ -3,6 +3,7 @@
 import type { AppActions } from "@/lib/app-data"
 import type { AppData } from "@/lib/types"
 import { ProductImportSection } from "../product/product-import-section"
+import { BulkSyncSection } from "./bulk-sync-section"
 
 interface BulkTabProps {
   data: AppData
@@ -12,6 +13,7 @@ interface BulkTabProps {
 export function BulkTab({ data, actions }: BulkTabProps) {
   return (
     <div className="space-y-6">
+      <BulkSyncSection />
       <ProductImportSection data={data} actions={actions} />
     </div>
   )

--- a/src/app/api/bulk-sync/apply/route.ts
+++ b/src/app/api/bulk-sync/apply/route.ts
@@ -1,0 +1,132 @@
+import { NextResponse } from "next/server"
+import { cookies } from "next/headers"
+import { createClient } from "@supabase/supabase-js"
+
+import { prepareBulkSyncApply } from "@/lib/bulk-sync/apply"
+import { validateBulkSyncPayload } from "@/lib/bulk-sync"
+import { loadUserAppDataServer } from "@/lib/server/load-app-data"
+import type { BulkSyncPayload } from "@/lib/bulk-sync"
+
+export const runtime = "nodejs"
+
+type ApplyOptions = {
+  dryRun?: boolean
+  recordAuditLog?: boolean
+}
+
+export async function POST(request: Request) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return NextResponse.json({ error: "Supabase env vars missing" }, { status: 500 })
+  }
+
+  let accessToken: string | undefined
+  const authHeader = request.headers.get("authorization")
+  if (authHeader?.toLowerCase().startsWith("bearer ")) {
+    accessToken = authHeader.slice(7)
+  }
+
+  const cookieStore = await cookies()
+  if (!accessToken) {
+    const projectRef = extractProjectRef(supabaseUrl)
+    const cookieName = projectRef ? `sb-${projectRef}-auth-token` : undefined
+    const tokenCookie = cookieName ? cookieStore.get(cookieName) : undefined
+    if (!tokenCookie?.value) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    try {
+      const [access] = JSON.parse(tokenCookie.value)
+      accessToken = access
+    } catch (error) {
+      console.error("Failed to parse Supabase auth cookie", { cookieName, error })
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    if (!accessToken) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+    global: {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+    auth: {
+      persistSession: false,
+    },
+  })
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  let body: { payload?: BulkSyncPayload; options?: ApplyOptions } | null = null
+  try {
+    body = (await request.json()) as { payload?: BulkSyncPayload; options?: ApplyOptions }
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
+  }
+
+  if (!body?.payload) {
+    return NextResponse.json({ error: "payload is required" }, { status: 400 })
+  }
+
+  const options = body.options ?? {}
+
+  try {
+    const existing = await loadUserAppDataServer(supabase, user.id)
+    const { normalized, issues } = validateBulkSyncPayload(body.payload, existing)
+    const prepared = prepareBulkSyncApply(normalized, existing, issues)
+
+    if (!options.dryRun) {
+      const { error } = await supabase.rpc("sync_app_data", {
+        p_user_id: user.id,
+        p_payload: prepared.payload,
+      })
+      if (error) {
+        console.error("Failed to apply bulk sync", error)
+        return NextResponse.json({ error: "Failed to apply bulk sync" }, { status: 500 })
+      }
+
+      if (options.recordAuditLog) {
+        const { error: auditError } = await supabase.from("sync_audit_logs").insert({
+          user_id: user.id,
+          device_info: request.headers.get("user-agent") ?? undefined,
+          metadata: {
+            action: "bulk_sync_apply",
+            summary: prepared.summary,
+            errorCount: prepared.errors.length,
+          },
+        })
+        if (auditError) {
+          console.warn("Failed to record bulk sync audit log", auditError)
+        }
+      }
+    }
+
+    return NextResponse.json({
+      jobId: "local",
+      status: "completed",
+      summary: prepared.summary,
+      errors: prepared.errors,
+    })
+  } catch (error) {
+    console.error("Failed to process bulk sync apply", error)
+    return NextResponse.json({ error: "Failed to apply bulk sync" }, { status: 500 })
+  }
+}
+
+const projectRefPattern = /https?:\/\/([a-z0-9-]+)\.supabase\.co/i
+
+function extractProjectRef(url: string) {
+  return url.match(projectRefPattern)?.[1]
+}

--- a/src/lib/bulk-sync/apply.test.ts
+++ b/src/lib/bulk-sync/apply.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest"
+
+import { prepareBulkSyncApply } from "./apply"
+import { emptyAppData } from "../types"
+import type { NormalizedPayload } from "./types"
+
+const normalizedBase: NormalizedPayload = {
+  categories_large: [],
+  categories_medium: [],
+  categories_small: [],
+  materials: [],
+  packaging_items: [],
+  shipping_methods: [],
+  labor_roles: [],
+  equipments: [],
+  fees: [],
+  option_presets: [],
+  products: [],
+}
+
+describe("prepareBulkSyncApply", () => {
+  it("resolves delete by natural key", () => {
+    const normalized: NormalizedPayload = {
+      ...normalizedBase,
+      materials: [
+        {
+          entity: "materials",
+          id: undefined,
+          naturalKey: "コットン::Supplier",
+          isDeleted: true,
+          data: { name: "コットン", supplier: "Supplier" },
+        },
+      ],
+    }
+
+    const existing = {
+      ...emptyAppData,
+      materials: [
+        {
+          id: "mat-1",
+          name: "コットン",
+          unit: "m",
+          sizeDescription: "",
+          currency: "JPY",
+          unitCost: 100,
+          unitsPerBatch: 1,
+          supplier: "Supplier",
+          note: "",
+        },
+      ],
+    }
+
+    const result = prepareBulkSyncApply(normalized, existing, [])
+    const deleted = result.payload.materials_deleted as Array<{ id: string }>
+    expect(deleted).toHaveLength(1)
+    expect(deleted[0].id).toBe("mat-1")
+  })
+
+  it("fails when referenced category is missing", () => {
+    const normalized: NormalizedPayload = {
+      ...normalizedBase,
+      products: [
+        {
+          entity: "products",
+          id: undefined,
+          naturalKey: "バッグA",
+          isDeleted: false,
+          data: {
+            product_name: "バッグA",
+            sale_price: 1000,
+            base_man_hours: 1,
+            expected_quantity: 10,
+            category_large: "存在しない",
+          },
+        },
+      ],
+    }
+
+    const result = prepareBulkSyncApply(normalized, emptyAppData, [])
+    expect(result.errors.some((error) => error.message.includes("カテゴリ(大)が解決できません"))).toBe(true)
+    const products = result.payload.products as Array<unknown>
+    expect(products).toHaveLength(0)
+  })
+})

--- a/src/lib/bulk-sync/apply.ts
+++ b/src/lib/bulk-sync/apply.ts
@@ -1,0 +1,506 @@
+import type { AppData } from "../types"
+import type {
+  BulkSyncEntity,
+  DiffSummary,
+  NormalizedPayload,
+  NormalizedRecord,
+  ValidationIssue,
+} from "./types"
+
+export type BulkSyncApplyError = {
+  entity: BulkSyncEntity
+  rowIndex?: number
+  message: string
+  code: "VALIDATION_ERROR" | "NOT_FOUND"
+}
+
+export type BulkSyncApplySummary = DiffSummary & {
+  success: number
+  failed: number
+}
+
+export type BulkSyncApplyResult = {
+  payload: Record<string, unknown>
+  summary: BulkSyncApplySummary
+  errors: BulkSyncApplyError[]
+}
+
+const issueKey = (entity: BulkSyncEntity, record: NormalizedRecord) => `${entity}#${record.id ?? record.naturalKey}`
+
+const buildIssueMap = (issues: ValidationIssue[]) => {
+  const map = new Map<string, ValidationIssue[]>()
+  issues.forEach((issue) => {
+    const key = `${issue.entity}#${issue.key}`
+    const list = map.get(key) ?? []
+    list.push(issue)
+    map.set(key, list)
+  })
+  return map
+}
+
+type ExistingIndex = {
+  byId: Map<string, { id: string; naturalKey: string }>
+  byNaturalKey: Map<string, { id: string; naturalKey: string }>
+  categoryNames: {
+    largeByName: Map<string, string>
+    mediumByName: Map<string, { id: string; largeId: string }>
+    smallByName: Map<string, { id: string; mediumId: string; largeId: string }>
+  }
+  equipmentByName: Map<string, string>
+}
+
+const buildExistingIndex = (existing: AppData): ExistingIndex => {
+  const byId = new Map<string, { id: string; naturalKey: string }>()
+  const byNaturalKey = new Map<string, { id: string; naturalKey: string }>()
+
+  const largeNameById = new Map(existing.categories.large.map((item) => [item.id, item.name]))
+  const mediumById = new Map(existing.categories.medium.map((item) => [item.id, item]))
+
+  existing.categories.large.forEach((item) => {
+    const naturalKey = item.name
+    byId.set(`categories_large#${item.id}`, { id: item.id, naturalKey })
+    byNaturalKey.set(`categories_large#${naturalKey}`, { id: item.id, naturalKey })
+  })
+
+  existing.categories.medium.forEach((item) => {
+    const largeName = largeNameById.get(item.largeId) ?? item.largeId
+    const naturalKey = `${largeName}::${item.name}`
+    byId.set(`categories_medium#${item.id}`, { id: item.id, naturalKey })
+    byNaturalKey.set(`categories_medium#${naturalKey}`, { id: item.id, naturalKey })
+  })
+
+  existing.categories.small.forEach((item) => {
+    const medium = mediumById.get(item.mediumId)
+    const largeName = medium ? largeNameById.get(medium.largeId) : undefined
+    const mediumName = medium?.name ?? item.mediumId
+    const naturalKey = `${largeName ?? ""}::${mediumName}::${item.name}`
+    byId.set(`categories_small#${item.id}`, { id: item.id, naturalKey })
+    byNaturalKey.set(`categories_small#${naturalKey}`, { id: item.id, naturalKey })
+  })
+
+  existing.materials.forEach((item) => {
+    const naturalKey = item.supplier ? `${item.name}::${item.supplier}` : item.name
+    byId.set(`materials#${item.id}`, { id: item.id, naturalKey })
+    byNaturalKey.set(`materials#${naturalKey}`, { id: item.id, naturalKey })
+  })
+
+  existing.packagingItems.forEach((item) => {
+    const naturalKey = item.name
+    byId.set(`packaging_items#${item.id}`, { id: item.id, naturalKey })
+    byNaturalKey.set(`packaging_items#${naturalKey}`, { id: item.id, naturalKey })
+  })
+
+  existing.shippingMethods.forEach((item) => {
+    const naturalKey = item.name
+    byId.set(`shipping_methods#${item.id}`, { id: item.id, naturalKey })
+    byNaturalKey.set(`shipping_methods#${naturalKey}`, { id: item.id, naturalKey })
+  })
+
+  existing.laborRoles.forEach((item) => {
+    const naturalKey = item.name
+    byId.set(`labor_roles#${item.id}`, { id: item.id, naturalKey })
+    byNaturalKey.set(`labor_roles#${naturalKey}`, { id: item.id, naturalKey })
+  })
+
+  existing.equipments.forEach((item) => {
+    const naturalKey = item.name
+    byId.set(`equipments#${item.id}`, { id: item.id, naturalKey })
+    byNaturalKey.set(`equipments#${naturalKey}`, { id: item.id, naturalKey })
+  })
+
+  existing.fees.forEach((item) => {
+    const naturalKey = item.name
+    byId.set(`fees#${item.id}`, { id: item.id, naturalKey })
+    byNaturalKey.set(`fees#${naturalKey}`, { id: item.id, naturalKey })
+  })
+
+  existing.optionPresets.forEach((item) => {
+    const naturalKey = item.name
+    byId.set(`option_presets#${item.id}`, { id: item.id, naturalKey })
+    byNaturalKey.set(`option_presets#${naturalKey}`, { id: item.id, naturalKey })
+  })
+
+  existing.products.forEach((item) => {
+    const naturalKey = item.name
+    byId.set(`products#${item.id}`, { id: item.id, naturalKey })
+    byNaturalKey.set(`products#${naturalKey}`, { id: item.id, naturalKey })
+  })
+
+  const largeByName = new Map(existing.categories.large.map((item) => [item.name, item.id]))
+  const mediumByName = new Map(
+    existing.categories.medium.map((item) => [`${item.largeId}::${item.name}`, { id: item.id, largeId: item.largeId }])
+  )
+  const smallByName = new Map(
+    existing.categories.small.map((item) => {
+      const medium = mediumById.get(item.mediumId)
+      const largeId = medium?.largeId ?? ""
+      return [`${largeId}::${item.mediumId}::${item.name}`, { id: item.id, mediumId: item.mediumId, largeId }]
+    })
+  )
+
+  const equipmentByName = new Map(existing.equipments.map((item) => [item.name, item.id]))
+
+  return {
+    byId,
+    byNaturalKey,
+    categoryNames: {
+      largeByName,
+      mediumByName,
+      smallByName,
+    },
+    equipmentByName,
+  }
+}
+
+const resolveExistingId = (index: ExistingIndex, entity: BulkSyncEntity, record: NormalizedRecord) => {
+  if (record.id) return record.id
+  const byNaturalKey = index.byNaturalKey.get(`${entity}#${record.naturalKey}`)
+  return byNaturalKey?.id
+}
+
+const buildSummary = (total: number, applied: number, failed: number): BulkSyncApplySummary => ({
+  total,
+  create: 0,
+  update: 0,
+  delete: 0,
+  success: applied,
+  failed,
+})
+
+const collectErrors = (issues: ValidationIssue[], records: NormalizedRecord[]) => {
+  const errorMap = new Map<string, ValidationIssue[]>()
+  issues
+    .filter((issue) => issue.severity === "error")
+    .forEach((issue) => {
+      const key = `${issue.entity}#${issue.key}`
+      const list = errorMap.get(key) ?? []
+      list.push(issue)
+      errorMap.set(key, list)
+    })
+
+  return records.flatMap((record) => {
+    const key = `${record.entity}#${record.id ?? record.naturalKey}`
+    const recordIssues = errorMap.get(key) ?? []
+    return recordIssues.map<BulkSyncApplyError>((issue) => ({
+      entity: record.entity,
+      rowIndex: record.rowIndex,
+      message: issue.message,
+      code: "VALIDATION_ERROR",
+    }))
+  })
+}
+
+const parseEquipmentNames = (value: unknown) => {
+  if (typeof value !== "string") return []
+  return value
+    .split("|")
+    .map((name) => name.trim())
+    .filter(Boolean)
+}
+
+const getString = (value: unknown) => (typeof value === "string" ? value : undefined)
+
+const getNumber = (value: unknown) => (typeof value === "number" && Number.isFinite(value) ? value : undefined)
+
+export const prepareBulkSyncApply = (
+  normalized: NormalizedPayload,
+  existing: AppData,
+  issues: ValidationIssue[]
+): BulkSyncApplyResult => {
+  const issueMap = buildIssueMap(issues)
+  const existingIndex = buildExistingIndex(existing)
+  const failedKeys = new Set<string>()
+
+  const applyRecords: NormalizedRecord[] = []
+  const deleteRecords: NormalizedRecord[] = []
+  const allRecords: NormalizedRecord[] = []
+
+  Object.values(normalized).forEach((records) => {
+    records.forEach((record) => {
+      allRecords.push(record)
+      const recordIssues = issueMap.get(issueKey(record.entity, record)) ?? []
+      const hasError = recordIssues.some((issue) => issue.severity === "error")
+      if (hasError) {
+        failedKeys.add(issueKey(record.entity, record))
+        return
+      }
+      if (record.isDeleted) {
+        deleteRecords.push(record)
+      } else {
+        applyRecords.push(record)
+      }
+    })
+  })
+
+  const errors = collectErrors(issues, allRecords)
+
+  const addRecordError = (record: NormalizedRecord, message: string, code: BulkSyncApplyError["code"]) => {
+    errors.push({
+      entity: record.entity,
+      rowIndex: record.rowIndex,
+      message,
+      code,
+    })
+    failedKeys.add(issueKey(record.entity, record))
+  }
+
+  const payload: Record<string, unknown> = {
+    categories_large: [],
+    categories_large_deleted: [],
+    categories_medium: [],
+    categories_medium_deleted: [],
+    categories_small: [],
+    categories_small_deleted: [],
+    materials: [],
+    materials_deleted: [],
+    packaging_items: [],
+    packaging_items_deleted: [],
+    shipping_methods: [],
+    shipping_methods_deleted: [],
+    labor_roles: [],
+    labor_roles_deleted: [],
+    equipments: [],
+    equipments_deleted: [],
+    fees: [],
+    fees_deleted: [],
+    option_presets: [],
+    option_presets_deleted: [],
+    products: [],
+    products_deleted: [],
+  }
+
+  let createCount = 0
+  let updateCount = 0
+  let deleteCount = 0
+
+  const addDelete = (entity: BulkSyncEntity, record: NormalizedRecord) => {
+    const resolvedId = resolveExistingId(existingIndex, entity, record)
+    if (!resolvedId) {
+      addRecordError(record, "削除対象のIDが見つかりません", "NOT_FOUND")
+      return
+    }
+    const target = `${entity}_deleted`
+    ;(payload[target] as Array<{ id: string }>).push({ id: resolvedId })
+    deleteCount += 1
+  }
+
+  deleteRecords.forEach((record) => addDelete(record.entity, record))
+
+  const { largeByName, mediumByName } = existingIndex.categoryNames
+  const smallByName = existingIndex.categoryNames.smallByName
+
+  const resolveCategoryIdsForProduct = (record: NormalizedRecord) => {
+    const largeName = getString(record.data.category_large)
+    const mediumName = getString(record.data.category_medium)
+    const smallName = getString(record.data.category_small)
+
+    const largeId = largeName ? largeByName.get(largeName) : undefined
+    let mediumId: string | undefined
+    if (mediumName && largeId) {
+      mediumId = mediumByName.get(`${largeId}::${mediumName}`)?.id
+    }
+    let smallId: string | undefined
+    if (smallName && mediumId) {
+      smallId = smallByName.get(`${largeId ?? ""}::${mediumId}::${smallName}`)?.id
+    }
+
+    if (largeName && !largeId) {
+      addRecordError(record, `カテゴリ(大)が解決できません: ${largeName}`, "NOT_FOUND")
+    }
+
+    if (mediumName && !mediumId) {
+      addRecordError(record, `カテゴリ(中)が解決できません: ${mediumName}`, "NOT_FOUND")
+    }
+
+    if (smallName && !smallId) {
+      addRecordError(record, `カテゴリ(小)が解決できません: ${smallName}`, "NOT_FOUND")
+    }
+
+    return { largeId, mediumId, smallId }
+  }
+
+  const resolveEquipmentIds = (record: NormalizedRecord) => {
+    const names = parseEquipmentNames(record.data.equipment_names)
+    return names
+      .map((name) => ({ name, id: existingIndex.equipmentByName.get(name) }))
+      .filter((entry) => {
+        if (!entry.id) {
+          addRecordError(record, `設備が解決できません: ${entry.name}`, "NOT_FOUND")
+          return false
+        }
+        return true
+      })
+      .map((entry) => entry.id as string)
+  }
+
+  applyRecords.forEach((record) => {
+    const recordKey = issueKey(record.entity, record)
+    const resolvedId = resolveExistingId(existingIndex, record.entity, record)
+    const id = record.id ?? resolvedId
+
+    switch (record.entity) {
+      case "categories_large":
+        ;(payload.categories_large as Array<Record<string, unknown>>).push({
+          id,
+          name: record.data.name,
+          description: record.data.description ?? null,
+        })
+        if (resolvedId) updateCount += 1
+        else createCount += 1
+        break
+      case "categories_medium": {
+        const largeId = getString(record.data.large_id)
+        ;(payload.categories_medium as Array<Record<string, unknown>>).push({
+          id,
+          name: record.data.name,
+          description: record.data.description ?? null,
+          large_id: largeId ?? null,
+        })
+        if (resolvedId) updateCount += 1
+        else createCount += 1
+        break
+      }
+      case "categories_small": {
+        const mediumId = getString(record.data.medium_id)
+        ;(payload.categories_small as Array<Record<string, unknown>>).push({
+          id,
+          name: record.data.name,
+          description: record.data.description ?? null,
+          medium_id: mediumId ?? null,
+        })
+        if (resolvedId) updateCount += 1
+        else createCount += 1
+        break
+      }
+      case "materials":
+        ;(payload.materials as Array<Record<string, unknown>>).push({
+          id,
+          name: record.data.name,
+          unit: record.data.unit ?? null,
+          size_description: record.data.size_description ?? null,
+          currency: record.data.currency ?? "JPY",
+          unit_cost: record.data.unit_cost ?? null,
+          supplier: record.data.supplier ?? null,
+          note: record.data.note ?? null,
+          units_per_batch: record.data.units_per_batch ?? null,
+        })
+        if (resolvedId) updateCount += 1
+        else createCount += 1
+        break
+      case "packaging_items":
+        ;(payload.packaging_items as Array<Record<string, unknown>>).push({
+          id,
+          name: record.data.name,
+          unit: record.data.unit ?? null,
+          size_description: record.data.size_description ?? null,
+          currency: record.data.currency ?? "JPY",
+          unit_cost: record.data.unit_cost ?? null,
+          note: record.data.note ?? null,
+          units_per_batch: record.data.units_per_batch ?? null,
+        })
+        if (resolvedId) updateCount += 1
+        else createCount += 1
+        break
+      case "shipping_methods":
+        ;(payload.shipping_methods as Array<Record<string, unknown>>).push({
+          id,
+          name: record.data.name,
+          unit_cost: record.data.unit_cost ?? null,
+          currency: record.data.currency ?? "JPY",
+          note: record.data.note ?? null,
+          description: record.data.description ?? null,
+        })
+        if (resolvedId) updateCount += 1
+        else createCount += 1
+        break
+      case "labor_roles":
+        ;(payload.labor_roles as Array<Record<string, unknown>>).push({
+          id,
+          name: record.data.name,
+          hourly_rate: record.data.hourly_rate ?? null,
+          currency: record.data.currency ?? "JPY",
+          note: record.data.note ?? null,
+        })
+        if (resolvedId) updateCount += 1
+        else createCount += 1
+        break
+      case "equipments":
+        ;(payload.equipments as Array<Record<string, unknown>>).push({
+          id,
+          name: record.data.name,
+          acquisition_cost: record.data.acquisition_cost ?? null,
+          currency: record.data.currency ?? "JPY",
+          amortization_years: record.data.amortization_years ?? null,
+          utilization_rate: record.data.utilization_rate ?? 100,
+          note: record.data.note ?? null,
+        })
+        if (resolvedId) updateCount += 1
+        else createCount += 1
+        break
+      case "fees":
+        ;(payload.fees as Array<Record<string, unknown>>).push({
+          id,
+          name: record.data.name,
+          rate_percent: record.data.rate_percent ?? null,
+          fixed_amount: record.data.fixed_amount ?? null,
+          currency: record.data.currency ?? "JPY",
+          note: record.data.note ?? null,
+        })
+        if (resolvedId) updateCount += 1
+        else createCount += 1
+        break
+      case "option_presets":
+        ;(payload.option_presets as Array<Record<string, unknown>>).push({
+          id,
+          name: record.data.name,
+          variants: record.data.variants ?? [],
+        })
+        if (resolvedId) updateCount += 1
+        else createCount += 1
+        break
+      case "products": {
+        const { largeId, mediumId, smallId } = resolveCategoryIdsForProduct(record)
+        const equipmentIds = resolveEquipmentIds(record)
+        const registeredAt = getString(record.data.registered_at) ?? new Date().toISOString()
+        if (failedKeys.has(recordKey)) return
+        ;(payload.products as Array<Record<string, unknown>>).push({
+          id,
+          name: record.data.product_name,
+          category_large_id: largeId ?? null,
+          category_medium_id: mediumId ?? null,
+          category_small_id: smallId ?? null,
+          size_variants: record.data.size_variants ?? [],
+          base_man_hours: record.data.base_man_hours ?? null,
+          default_electricity_cost: record.data.default_electricity_cost ?? null,
+          sale_price: record.data.sale_price ?? null,
+          registered_at: registeredAt,
+          notes: record.data.notes ?? null,
+          production_lot_size: record.data.production_lot_size ?? 1,
+          expected_production_period_years: record.data.expected_period_years ?? 1,
+          expected_production_quantity: record.data.expected_quantity ?? null,
+          equipment_ids: equipmentIds,
+        })
+        if (resolvedId) updateCount += 1
+        else createCount += 1
+        break
+      }
+      default:
+        break
+    }
+  })
+
+  const total = allRecords.length
+  const failed = Math.min(failedKeys.size, total)
+  const success = Math.max(total - failed, 0)
+
+  return {
+    payload,
+    summary: {
+      ...buildSummary(total, success, failed),
+      create: createCount,
+      update: updateCount,
+      delete: deleteCount,
+    },
+    errors,
+  }
+}

--- a/src/lib/bulk-sync/ui-utils.test.ts
+++ b/src/lib/bulk-sync/ui-utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+
+import { parsePayloadJson } from "./ui-utils"
+
+describe("parsePayloadJson", () => {
+  it("rejects empty input", () => {
+    const result = parsePayloadJson(" ")
+    expect(result.payload).toBeNull()
+    expect(result.error).toBeDefined()
+  })
+
+  it("parses valid json", () => {
+    const result = parsePayloadJson('{"materials":[]}')
+    expect(result.payload).toEqual({ materials: [] })
+  })
+
+  it("rejects invalid json", () => {
+    const result = parsePayloadJson("{")
+    expect(result.payload).toBeNull()
+    expect(result.error).toBeDefined()
+  })
+})

--- a/src/lib/bulk-sync/ui-utils.ts
+++ b/src/lib/bulk-sync/ui-utils.ts
@@ -1,0 +1,17 @@
+import type { BulkSyncPayload } from "./types"
+
+export const parsePayloadJson = (input: string): { payload: BulkSyncPayload | null; error?: string } => {
+  const trimmed = input.trim()
+  if (!trimmed) {
+    return { payload: null, error: "JSON が空です" }
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as BulkSyncPayload
+    if (!parsed || typeof parsed !== "object") {
+      return { payload: null, error: "JSON の形式が不正です" }
+    }
+    return { payload: parsed }
+  } catch (error) {
+    return { payload: null, error: "JSON の解析に失敗しました" }
+  }
+}

--- a/src/lib/bulk-sync/validation.ts
+++ b/src/lib/bulk-sync/validation.ts
@@ -174,8 +174,10 @@ const buildCategoryMaps = (payload: NormalizedPayload, existing: AppData) => {
   })
   payload.categories_large.forEach((record) => {
     const name = asString(record.data.name)
-    if (record.id) largeById.set(record.id, name)
-    if (name) largeByName.set(name, record.id ?? name)
+    if (record.id) {
+      largeById.set(record.id, name)
+      if (name) largeByName.set(name, record.id)
+    }
   })
 
   const mediumById = new Map<string, { name: string; largeId: string }>()
@@ -197,7 +199,7 @@ const buildCategoryMaps = (payload: NormalizedPayload, existing: AppData) => {
   existing.equipments.forEach((item) => equipmentByName.set(item.name, item.id))
   payload.equipments.forEach((record) => {
     const name = asString(record.data.name)
-    if (name) equipmentByName.set(name, record.id ?? name)
+    if (name && record.id) equipmentByName.set(name, record.id)
   })
 
   return { largeById, largeByName, mediumById, mediumByName, equipmentByName } satisfies CategoryMaps


### PR DESCRIPTION
## 概要
一括反映の UI と API を追加し、差分確認〜反映結果サマリ/エラー詳細まで確認できるようにしました。

## 変更点
- 一括反映 UI（JSON 入力、差分確認、反映実行、進捗/サマリ/エラー表示）を追加
- `/api/bulk-sync/apply` を実装（部分反映 + サマリ返却）
- 参照解決の厳密化（新規は ID 必須、既存参照は ID/自然キーで解決）
- UI 用ユーティリティとテスト追加

## テスト
- `npm test`

## 補足
- UI は `Bulk` タブに配置しています。