### PR TITLE
#18 一括反映の監査ログに差分一覧を記録

### DIFF
--- a/src/app/_components/audit/audit-tab.tsx
+++ b/src/app/_components/audit/audit-tab.tsx
@@ -45,12 +45,21 @@ const describeClient = (log: AuditLog) => {
 
 const renderChangeList = (label: string, summary?: ChangeSummary) => {
   if (!summary) return null
-  if ((summary.added ?? []).length === 0 && (summary.removed ?? []).length === 0) return null
+  if (
+    (summary.added ?? []).length === 0 &&
+    (summary.removed ?? []).length === 0 &&
+    (summary.updated ?? []).length === 0
+  ) {
+    return null
+  }
   return (
     <div>
       <p className="font-medium text-foreground">{label}</p>
       {summary.added.length > 0 && (
         <p className="text-xs text-emerald-600">追加: {summary.added.join(", ")}</p>
+      )}
+      {summary.updated && summary.updated.length > 0 && (
+        <p className="text-xs text-sky-600">更新: {summary.updated.join(", ")}</p>
       )}
       {summary.removed.length > 0 && (
         <p className="text-xs text-rose-600">削除: {summary.removed.join(", ")}</p>

--- a/src/app/api/bulk-sync/apply/route.ts
+++ b/src/app/api/bulk-sync/apply/route.ts
@@ -3,9 +3,10 @@ import { cookies } from "next/headers"
 import { createClient } from "@supabase/supabase-js"
 
 import { prepareBulkSyncApply } from "@/lib/bulk-sync/apply"
-import { validateBulkSyncPayload } from "@/lib/bulk-sync"
+import { validateBulkSyncPayload, buildBulkSyncDiff } from "@/lib/bulk-sync"
 import { loadUserAppDataServer } from "@/lib/server/load-app-data"
 import type { BulkSyncPayload } from "@/lib/bulk-sync"
+import { buildBulkSyncAuditChanges } from "@/lib/bulk-sync/audit"
 
 export const runtime = "nodejs"
 
@@ -86,6 +87,7 @@ export async function POST(request: Request) {
     const existing = await loadUserAppDataServer(supabase, user.id)
     const { normalized, issues } = validateBulkSyncPayload(body.payload, existing)
     const prepared = prepareBulkSyncApply(normalized, existing, issues)
+    const diff = buildBulkSyncDiff(normalized, existing, issues)
 
     if (!options.dryRun) {
       const { error } = await supabase.rpc("sync_app_data", {
@@ -105,6 +107,7 @@ export async function POST(request: Request) {
             action: "bulk_sync_apply",
             summary: prepared.summary,
             errorCount: prepared.errors.length,
+            changes: buildBulkSyncAuditChanges(diff.items, existing),
             previousData: existing,
           },
         })

--- a/src/lib/bulk-sync/audit.test.ts
+++ b/src/lib/bulk-sync/audit.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+
+import { buildBulkSyncAuditChanges } from "./audit"
+import type { DiffItem } from "./types"
+import { emptyAppData } from "../types"
+
+describe("buildBulkSyncAuditChanges", () => {
+  it("collects added/updated/removed labels", () => {
+    const existing = {
+      ...emptyAppData,
+      materials: [
+        {
+          id: "mat-1",
+          name: "コットン",
+          unit: "m",
+          sizeDescription: "",
+          currency: "JPY",
+          unitCost: 100,
+          unitsPerBatch: 1,
+          supplier: "",
+          note: "",
+        },
+      ],
+    }
+
+    const items: DiffItem[] = [
+      {
+        entity: "materials",
+        operation: "update",
+        key: { id: "mat-1", naturalKey: "コットン" },
+        before: null,
+        after: null,
+        issues: [],
+      },
+      {
+        entity: "materials",
+        operation: "create",
+        key: { naturalKey: "リネン" },
+        before: null,
+        after: null,
+        issues: [],
+      },
+      {
+        entity: "materials",
+        operation: "delete",
+        key: { naturalKey: "削除対象" },
+        before: null,
+        after: null,
+        issues: [],
+      },
+    ]
+
+    const changes = buildBulkSyncAuditChanges(items, existing)
+    expect(changes.materials?.updated).toContain("コットン")
+    expect(changes.materials?.added).toContain("リネン")
+    expect(changes.materials?.removed).toContain("削除対象")
+  })
+})

--- a/src/lib/bulk-sync/audit.ts
+++ b/src/lib/bulk-sync/audit.ts
@@ -1,0 +1,120 @@
+import type { AppData } from "../types"
+import type { BulkSyncEntity, DiffItem } from "./types"
+
+type ChangeSummary = {
+  added: string[]
+  removed: string[]
+  updated: string[]
+}
+
+type BulkSyncAuditChanges = {
+  products?: ChangeSummary
+  materials?: ChangeSummary
+  packaging?: ChangeSummary
+  shippingMethods?: ChangeSummary
+  laborRoles?: ChangeSummary
+  equipments?: ChangeSummary
+  optionPresets?: ChangeSummary
+  fees?: ChangeSummary
+  categoriesLarge?: ChangeSummary
+  categoriesMedium?: ChangeSummary
+  categoriesSmall?: ChangeSummary
+}
+
+const createSummary = (): ChangeSummary => ({ added: [], removed: [], updated: [] })
+
+const mapEntity = (entity: BulkSyncEntity) => {
+  switch (entity) {
+    case "products":
+      return "products"
+    case "materials":
+      return "materials"
+    case "packaging_items":
+      return "packaging"
+    case "shipping_methods":
+      return "shippingMethods"
+    case "labor_roles":
+      return "laborRoles"
+    case "equipments":
+      return "equipments"
+    case "fees":
+      return "fees"
+    case "option_presets":
+      return "optionPresets"
+    case "categories_large":
+      return "categoriesLarge"
+    case "categories_medium":
+      return "categoriesMedium"
+    case "categories_small":
+      return "categoriesSmall"
+    default:
+      return null
+  }
+}
+
+const toLabel = (entity: BulkSyncEntity, item: DiffItem, existing: AppData) => {
+  if (item.key.naturalKey) return item.key.naturalKey
+  if (!item.key.id) return "(unknown)"
+  const id = item.key.id
+  switch (entity) {
+    case "products":
+      return existing.products.find((entry) => entry.id === id)?.name ?? id
+    case "materials":
+      return existing.materials.find((entry) => entry.id === id)?.name ?? id
+    case "packaging_items":
+      return existing.packagingItems.find((entry) => entry.id === id)?.name ?? id
+    case "shipping_methods":
+      return existing.shippingMethods.find((entry) => entry.id === id)?.name ?? id
+    case "labor_roles":
+      return existing.laborRoles.find((entry) => entry.id === id)?.name ?? id
+    case "equipments":
+      return existing.equipments.find((entry) => entry.id === id)?.name ?? id
+    case "fees":
+      return existing.fees.find((entry) => entry.id === id)?.name ?? id
+    case "option_presets":
+      return existing.optionPresets.find((entry) => entry.id === id)?.name ?? id
+    case "categories_large":
+      return existing.categories.large.find((entry) => entry.id === id)?.name ?? id
+    case "categories_medium":
+      return existing.categories.medium.find((entry) => entry.id === id)?.name ?? id
+    case "categories_small":
+      return existing.categories.small.find((entry) => entry.id === id)?.name ?? id
+    default:
+      return id
+  }
+}
+
+const pushUnique = (list: string[], value: string) => {
+  if (!value) return
+  if (list.includes(value)) return
+  list.push(value)
+}
+
+export const buildBulkSyncAuditChanges = (items: DiffItem[], existing: AppData): BulkSyncAuditChanges => {
+  const changes: BulkSyncAuditChanges = {}
+
+  items.forEach((item) => {
+    const mapped = mapEntity(item.entity)
+    if (!mapped) return
+    const summary = changes[mapped] ?? createSummary()
+    const label = toLabel(item.entity, item, existing)
+
+    switch (item.operation) {
+      case "create":
+        pushUnique(summary.added, label)
+        break
+      case "delete":
+        pushUnique(summary.removed, label)
+        break
+      case "update":
+        pushUnique(summary.updated, label)
+        break
+      default:
+        break
+    }
+
+    changes[mapped] = summary
+  })
+
+  return changes
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -247,6 +247,7 @@ export type AuditLogMetadata = {
 export type ChangeSummary = {
   added: string[]
   removed: string[]
+  updated?: string[]
 }
 
 export type AuditFilters = {


### PR DESCRIPTION
## 概要
一括反映時の監査ログに「変更対象名の一覧（追加/更新/削除）」を記録し、UIで参照できるようにしました。

## 変更点
- 差分一覧を生成する `buildBulkSyncAuditChanges` を追加
- 一括反映の監査ログに changes を保存
- 監査ログ UI で更新一覧を表示
- テスト追加

## テスト
- `npm test`
