### PR TITLE
ビルド修正: ロールバックの型ガード追加

### DIFF
--- a/src/app/api/bulk-sync/rollback/route.ts
+++ b/src/app/api/bulk-sync/rollback/route.ts
@@ -94,7 +94,12 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Rollback source not found" }, { status: 404 })
     }
 
-    const snapshot = normalizeAppData((log.metadata as { previousData?: unknown }).previousData)
+    const previousData = (log.metadata as { previousData?: unknown }).previousData
+    if (!previousData || typeof previousData !== "object") {
+      return NextResponse.json({ error: "Rollback source is invalid" }, { status: 400 })
+    }
+
+    const snapshot = normalizeAppData(previousData as Partial<import(\"@/lib/types\").AppData>)
     const current = await loadUserAppDataServer(supabase, user.id)
 
     const payload = buildSyncPayloadFromAppData(snapshot, current)


### PR DESCRIPTION
## 概要
`/api/bulk-sync/rollback` の型チェックを追加し、`previousData` が不正な場合に 400 を返すようにしました。

## 変更点
- `previousData` の型ガードを追加

## テスト
- 未実施（型エラー修正のみ）
