### PR TITLE
PRにビルドチェックを追加

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,18 @@
+name: build
+
+on:
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build


### PR DESCRIPTION
## 概要
PR 作成時に `npm run build` を必須チェックとして走らせる CI を追加しました。

## 変更点
- GitHub Actions で build ジョブを追加

## 実行内容
- `npm ci`
- `npm run build`
