### PR TITLE
#21 マスタ/商品で一括反映UIを分割

### DIFF
--- a/src/app/_components/bulk/bulk-sync-section.tsx
+++ b/src/app/_components/bulk/bulk-sync-section.tsx
@@ -37,7 +37,14 @@ type ApplyResponse = {
   errors: { entity: string; rowIndex?: number; message: string; code: string }[]
 }
 
-export function BulkSyncSection() {
+type BulkSyncSectionProps = {
+  title: string
+  description: string
+  placeholder: string
+  helpText: string
+}
+
+export function BulkSyncSection({ title, description, placeholder, helpText }: BulkSyncSectionProps) {
   const [payloadInput, setPayloadInput] = useState("")
   const [diffResult, setDiffResult] = useState<DiffResponse | null>(null)
   const [applyResult, setApplyResult] = useState<ApplyResponse | null>(null)
@@ -171,8 +178,8 @@ export function BulkSyncSection() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>一括反映</CardTitle>
-        <CardDescription>スプレッドシートから生成した JSON を投入して差分と反映結果を確認します。</CardDescription>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
         <div className="space-y-2">
@@ -183,11 +190,11 @@ export function BulkSyncSection() {
           <Textarea
             id="bulk-sync-payload"
             rows={10}
-            placeholder='{"materials":[],"products":[]}'
+            placeholder={placeholder}
             value={payloadInput}
             onChange={(event) => setPayloadInput(event.target.value)}
           />
-          <p className="text-xs text-muted-foreground">`docs/spreadsheet-spec.md` と `docs/api/bulk-sync.md` の定義に準拠してください。</p>
+          <p className="text-xs text-muted-foreground">{helpText}</p>
         </div>
 
         <div className="grid gap-4 md:grid-cols-2">

--- a/src/app/_components/bulk/bulk-tab.tsx
+++ b/src/app/_components/bulk/bulk-tab.tsx
@@ -13,7 +13,18 @@ interface BulkTabProps {
 export function BulkTab({ data, actions }: BulkTabProps) {
   return (
     <div className="space-y-6">
-      <BulkSyncSection />
+      <BulkSyncSection
+        title="マスタ一括反映"
+        description="マスタ用シートから生成した JSON を投入して差分と反映結果を確認します。"
+        placeholder='{"materials":[],"packaging_items":[],"shipping_methods":[],"labor_roles":[],"equipments":[],"fees":[],"categories_large":[],"categories_medium":[],"categories_small":[]}'
+        helpText="マスタ項目は `docs/spreadsheet-spec.md` を参照してください。"
+      />
+      <BulkSyncSection
+        title="商品一括反映"
+        description="商品シートから生成した JSON を投入して差分と反映結果を確認します。"
+        placeholder='{"products":[]}'
+        helpText="商品項目は `docs/spreadsheet-spec.md` と `templates/product-import-template.csv` を参照してください。"
+      />
       <ProductImportSection data={data} actions={actions} />
     </div>
   )


### PR DESCRIPTION
## 概要
一括反映UIを「マスタ用」「商品用」で分け、入力導線を明確にしました。

## 変更点
- `BulkSyncSection` を汎用化
- マスタ用/商品用の入力欄を分割

## テスト
- `npm test`
