### PR TITLE
[UI] 一括同期のリクエストに認証Cookieを明示送信

### DIFF
--- a/src/app/_components/bulk/bulk-sync-section.tsx
+++ b/src/app/_components/bulk/bulk-sync-section.tsx
@@ -102,7 +102,7 @@ export function BulkSyncSection({ title, description, placeholder, helpText, tar
         return
       }
 
-      const response = await fetch("/api/bulk-sync/diff", requestInit)
+      const response = await fetch("/api/bulk-sync/diff", { ...requestInit, credentials: "include" })
 
       if (!response.ok) {
         const error = await response.json().catch(() => ({}))
@@ -135,6 +135,7 @@ export function BulkSyncSection({ title, description, placeholder, helpText, tar
             const result = await fetch("/api/bulk-sync/apply", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
+              credentials: "include",
               body: JSON.stringify({ payload: parsedPayload.payload, options: { dryRun, recordAuditLog } }),
             })
             if (!result.ok) {
@@ -147,6 +148,7 @@ export function BulkSyncSection({ title, description, placeholder, helpText, tar
           const result = await fetch("/api/bulk-sync/import", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
+            credentials: "include",
             body: JSON.stringify({ target, options: { dryRun, recordAuditLog } }),
           })
           if (!result.ok) {
@@ -181,7 +183,7 @@ export function BulkSyncSection({ title, description, placeholder, helpText, tar
     try {
       const response = await retry(
         async () => {
-          const result = await fetch("/api/bulk-sync/rollback", { method: "POST" })
+          const result = await fetch("/api/bulk-sync/rollback", { method: "POST", credentials: "include" })
           if (!result.ok) {
             const error = await result.json().catch(() => ({}))
             throw new Error(error.error ?? "ロールバックに失敗しました")
@@ -212,6 +214,7 @@ export function BulkSyncSection({ title, description, placeholder, helpText, tar
       const response = await fetch("/api/bulk-sync/export", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({ target, mode: exportMode }),
       })
       if (!response.ok) {


### PR DESCRIPTION
## 概要
本番で 401 が発生するケースがあるため、ブラウザからの `fetch` に `credentials: "include"` を明示して認証 Cookie を確実に送信する。

## 変更点
- `/api/bulk-sync/diff|export|import|apply|rollback` 呼び出しに `credentials: "include"` を追加

## 影響
- 同一オリジンであれば従来どおり動作
- 認証 Cookie が確実に送信されるため、401 を回避できる可能性が高い
