### PR TITLE
[不具合修正] 一括同期APIへアクセストークンを付与

### DIFF
--- a/src/app/_components/bulk/bulk-sync-section.tsx
+++ b/src/app/_components/bulk/bulk-sync-section.tsx
@@ -12,6 +12,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Textarea } from "@/components/ui/textarea"
 import { parsePayloadJson } from "@/lib/bulk-sync/ui-utils"
 import { retry } from "@/lib/bulk-sync/retry"
+import { supabaseClient } from "@/lib/supabase-client"
 
 const MAX_ERRORS = 200
 const MAX_ISSUES = 200
@@ -74,6 +75,19 @@ export function BulkSyncSection({ title, description, placeholder, helpText, tar
 
   const parsedPayload = useMemo(() => parsePayloadJson(payloadInput), [payloadInput])
 
+  const buildAuthHeaders = async (includeJson: boolean) => {
+    try {
+      const { data } = await supabaseClient.auth.getSession()
+      const accessToken = data.session?.access_token
+      return {
+        ...(includeJson ? { "Content-Type": "application/json" } : {}),
+        ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+      }
+    } catch {
+      return includeJson ? { "Content-Type": "application/json" } : {}
+    }
+  }
+
   const issueItems = useMemo(() => {
     if (!diffResult) return []
     return diffResult.items.filter((item) => item.issues.length > 0).slice(0, MAX_ISSUES)
@@ -87,14 +101,16 @@ export function BulkSyncSection({ title, description, placeholder, helpText, tar
     setBusy("diff")
     try {
       const trimmedInput = payloadInput.trim()
+      const headers = await buildAuthHeaders(useManualJson && trimmedInput.length > 0)
       const requestInit: RequestInit =
         useManualJson && trimmedInput.length > 0
           ? {
               method: "POST",
-              headers: { "Content-Type": "application/json" },
+              headers,
+              credentials: "include",
               body: JSON.stringify({ payload: parsedPayload.payload, options: { includeDetails: true } }),
             }
-          : { method: "POST" }
+          : { method: "POST", headers, credentials: "include" }
 
       if (useManualJson && trimmedInput.length > 0 && !parsedPayload.payload) {
         setErrorMessage(parsedPayload.error ?? "JSON を確認してください")
@@ -102,7 +118,7 @@ export function BulkSyncSection({ title, description, placeholder, helpText, tar
         return
       }
 
-      const response = await fetch("/api/bulk-sync/diff", { ...requestInit, credentials: "include" })
+      const response = await fetch("/api/bulk-sync/diff", requestInit)
 
       if (!response.ok) {
         const error = await response.json().catch(() => ({}))
@@ -132,9 +148,10 @@ export function BulkSyncSection({ title, description, placeholder, helpText, tar
       const response = await retry(
         async () => {
           if (useManualJson) {
+            const headers = await buildAuthHeaders(true)
             const result = await fetch("/api/bulk-sync/apply", {
               method: "POST",
-              headers: { "Content-Type": "application/json" },
+              headers,
               credentials: "include",
               body: JSON.stringify({ payload: parsedPayload.payload, options: { dryRun, recordAuditLog } }),
             })
@@ -145,9 +162,10 @@ export function BulkSyncSection({ title, description, placeholder, helpText, tar
             return result
           }
 
+          const headers = await buildAuthHeaders(true)
           const result = await fetch("/api/bulk-sync/import", {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers,
             credentials: "include",
             body: JSON.stringify({ target, options: { dryRun, recordAuditLog } }),
           })
@@ -183,7 +201,12 @@ export function BulkSyncSection({ title, description, placeholder, helpText, tar
     try {
       const response = await retry(
         async () => {
-          const result = await fetch("/api/bulk-sync/rollback", { method: "POST", credentials: "include" })
+          const headers = await buildAuthHeaders(false)
+          const result = await fetch("/api/bulk-sync/rollback", {
+            method: "POST",
+            headers,
+            credentials: "include",
+          })
           if (!result.ok) {
             const error = await result.json().catch(() => ({}))
             throw new Error(error.error ?? "ロールバックに失敗しました")
@@ -211,9 +234,10 @@ export function BulkSyncSection({ title, description, placeholder, helpText, tar
     setErrorMessage(null)
     setBusy("export")
     try {
+      const headers = await buildAuthHeaders(true)
       const response = await fetch("/api/bulk-sync/export", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers,
         credentials: "include",
         body: JSON.stringify({ target, mode: exportMode }),
       })


### PR DESCRIPTION
## 概要
本番で `/api/bulk-sync/diff` / `/api/bulk-sync/export` 等が 401 になるため、
フロントから Supabase のアクセストークンを取得し、Authorization ヘッダーを付与する。

## 変更点
- `supabaseClient.auth.getSession()` で access token を取得
- `diff / export / import / apply / rollback` の各リクエストに Authorization を付与
- 既存の Cookie 送信（credentials: include）は維持

## 期待される効果
- Cookie が届かない環境でも認証が通り、401 が解消される

