### PR TITLE
[整理] 旧商品インポートを折りたたみ表示に変更

### DIFF
--- a/src/app/_components/product/product-import-section.tsx
+++ b/src/app/_components/product/product-import-section.tsx
@@ -123,6 +123,7 @@ export function ProductImportSection({ data, actions }: ProductImportSectionProp
   const [targetUserId, setTargetUserId] = useState<string | null>(null)
   const [savingSheetSettings, setSavingSheetSettings] = useState(false)
   const [lookupLoading, setLookupLoading] = useState(false)
+  const [showLegacyImport, setShowLegacyImport] = useState(false)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
   const summary = useMemo(() => {
@@ -546,221 +547,241 @@ export function ProductImportSection({ data, actions }: ProductImportSectionProp
     <div className="space-y-6">
       <Card>
         <CardHeader>
-          <CardTitle>商品一括インポート</CardTitle>
-          <CardDescription>テンプレートから CSV を作成するか、共有スプレッドシートで編集して取り込めます</CardDescription>
+          <CardTitle>商品インポート（旧）</CardTitle>
+          <CardDescription>現在は「一括同期」タブのスプレッドシート連携を利用してください。</CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
-          <div className="space-y-3 rounded-md border p-4 text-xs">
-            <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div className="flex flex-col gap-3 rounded-md border bg-muted/20 p-3 text-xs">
+            <p className="text-sm font-medium">旧インポート機能について</p>
+            <p className="text-xs text-muted-foreground">
+              旧来の CSV / シート読み込みは必要に応じて残しています。通常運用は「一括同期」タブを利用してください。
+            </p>
+            <div>
+              <Button type="button" size="sm" variant="outline" onClick={() => setShowLegacyImport((prev) => !prev)}>
+                {showLegacyImport ? "旧インポートを隠す" : "旧インポートを表示"}
+              </Button>
+            </div>
+          </div>
+
+          {isSheetAdmin && (
+            <div className="rounded-md border border-dashed bg-background/70 p-3 space-y-3">
               <div>
-                <p className="text-sm font-medium">商品インポート（スプレッドシート）</p>
-                <p className="text-muted-foreground text-xs">
-                  共有済みのスプレッドシートから直接データを取得します。
+                <p className="text-sm font-medium">シート割り当て（管理者用）</p>
+                <p className="text-xs text-muted-foreground">
+                  メールアドレスを入力して対象ユーザーのシートID / タブ名を登録します。
                 </p>
               </div>
-              <Button
-                type="button"
-                size="sm"
-                variant="secondary"
-                onClick={handleFetchFromSheet}
-                disabled={fetchingSheet || sheetSettingsLoading || !mySheetSettings}
-              >
-                {fetchingSheet ? "取得中..." : "シートを読み込む"}
-              </Button>
-            </div>
-            <p className="text-muted-foreground text-sm">
-              {sheetSettingsLoading
-                ? "シート情報を読み込み中です..."
-                : mySheetSettings
-                    ? `連携シート: ${mySheetSettings.worksheetTitle}`
-                    : "連携設定が未登録です。管理者がシートID/タブ名を登録してください。"}
-            </p>
-            <div className="flex flex-wrap gap-2">
-              <Button type="button" size="sm" variant="outline" disabled={!mySheetSettings} asChild>
-                <a
-                  href={mySheetSettings ? `https://docs.google.com/spreadsheets/d/${mySheetSettings.spreadsheetId}/edit` : undefined}
-                  target="_blank"
-                  rel="noreferrer"
+              <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_auto]">
+                <Input
+                  value={sheetEmailInput}
+                  onChange={(event) => setSheetEmailInput(event.target.value)}
+                  placeholder="user@example.com"
+                />
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  onClick={handleLookupSheetSettings}
+                  disabled={lookupLoading}
                 >
-                  連携シートを開く
-                </a>
-              </Button>
-            </div>
-            {isSheetAdmin && (
-              <div className="rounded-md border border-dashed bg-background/70 p-3 space-y-3">
-                <div>
-                  <p className="text-sm font-medium">シート割り当て（管理者用）</p>
-                  <p className="text-xs text-muted-foreground">
-                    メールアドレスを入力して対象ユーザーのシートID / タブ名を登録します。
-                  </p>
-                </div>
-                <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_auto]">
+                  {lookupLoading ? "検索中..." : "ユーザーを検索"}
+                </Button>
+              </div>
+              {targetUserId ? (
+                <p className="text-xs text-muted-foreground break-all">対象ユーザーID: {targetUserId}</p>
+              ) : (
+                <p className="text-xs text-muted-foreground">検索すると該当ユーザーのシート情報が表示されます。</p>
+              )}
+              <div className="grid gap-2 md:grid-cols-2">
+                <div className="space-y-1">
+                  <Label className="text-xs text-muted-foreground">スプレッドシートID</Label>
                   <Input
-                    value={sheetEmailInput}
-                    onChange={(event) => setSheetEmailInput(event.target.value)}
-                    placeholder="user@example.com"
+                    value={sheetIdInput}
+                    onChange={(event) => setSheetIdInput(event.target.value)}
+                    placeholder="例: 1Bx8LW..."
                   />
+                </div>
+                <div className="space-y-1">
+                  <Label className="text-xs text-muted-foreground">タブ名</Label>
+                  <Input
+                    value={sheetTitleInput}
+                    onChange={(event) => setSheetTitleInput(event.target.value)}
+                    placeholder="例: シート1"
+                  />
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button type="button" size="sm" variant="default" onClick={handleSaveSheetSettings} disabled={savingSheetSettings || !targetUserId}>
+                  {savingSheetSettings ? "保存中..." : "シート設定を保存"}
+                </Button>
+                <Button type="button" size="sm" variant="outline" disabled={!adminSheetSettings} asChild>
+                  <a
+                    href={adminSheetSettings ? `https://docs.google.com/spreadsheets/d/${adminSheetSettings.spreadsheetId}/edit` : undefined}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    対象シートを開く
+                  </a>
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {showLegacyImport && (
+            <>
+              <div className="space-y-3 rounded-md border p-4 text-xs">
+                <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                  <div>
+                    <p className="text-sm font-medium">商品インポート（スプレッドシート）</p>
+                    <p className="text-muted-foreground text-xs">
+                      共有済みのスプレッドシートから直接データを取得します。
+                    </p>
+                  </div>
                   <Button
                     type="button"
                     size="sm"
                     variant="secondary"
-                    onClick={handleLookupSheetSettings}
-                    disabled={lookupLoading}
+                    onClick={handleFetchFromSheet}
+                    disabled={fetchingSheet || sheetSettingsLoading || !mySheetSettings}
                   >
-                    {lookupLoading ? "検索中..." : "ユーザーを検索"}
+                    {fetchingSheet ? "取得中..." : "シートを読み込む"}
                   </Button>
                 </div>
-                {targetUserId ? (
-                  <p className="text-xs text-muted-foreground break-all">対象ユーザーID: {targetUserId}</p>
-                ) : (
-                  <p className="text-xs text-muted-foreground">検索すると該当ユーザーのシート情報が表示されます。</p>
-                )}
-                <div className="grid gap-2 md:grid-cols-2">
-                  <div className="space-y-1">
-                    <Label className="text-xs text-muted-foreground">スプレッドシートID</Label>
-                    <Input
-                      value={sheetIdInput}
-                      onChange={(event) => setSheetIdInput(event.target.value)}
-                      placeholder="例: 1Bx8LW..."
-                    />
-                  </div>
-                  <div className="space-y-1">
-                    <Label className="text-xs text-muted-foreground">タブ名</Label>
-                    <Input
-                      value={sheetTitleInput}
-                      onChange={(event) => setSheetTitleInput(event.target.value)}
-                      placeholder="例: シート1"
-                    />
-                  </div>
-                </div>
+                <p className="text-muted-foreground text-sm">
+                  {sheetSettingsLoading
+                    ? "シート情報を読み込み中です..."
+                    : mySheetSettings
+                        ? `連携シート: ${mySheetSettings.worksheetTitle}`
+                        : "連携設定が未登録です。管理者がシートID/タブ名を登録してください。"}
+                </p>
                 <div className="flex flex-wrap gap-2">
-                  <Button type="button" size="sm" variant="default" onClick={handleSaveSheetSettings} disabled={savingSheetSettings || !targetUserId}>
-                    {savingSheetSettings ? "保存中..." : "シート設定を保存"}
-                  </Button>
-                  <Button type="button" size="sm" variant="outline" disabled={!adminSheetSettings} asChild>
+                  <Button type="button" size="sm" variant="outline" disabled={!mySheetSettings} asChild>
                     <a
-                      href={adminSheetSettings ? `https://docs.google.com/spreadsheets/d/${adminSheetSettings.spreadsheetId}/edit` : undefined}
+                      href={mySheetSettings ? `https://docs.google.com/spreadsheets/d/${mySheetSettings.spreadsheetId}/edit` : undefined}
                       target="_blank"
                       rel="noreferrer"
                     >
-                      対象シートを開く
+                      連携シートを開く
                     </a>
                   </Button>
                 </div>
               </div>
-            )}
-          </div>
 
-          <div className="space-y-4 rounded-md border p-4">
-            <div>
-              <p className="text-sm font-medium">商品インポート（CSV）</p>
-              <p className="text-xs text-muted-foreground">テンプレートで編集した CSV をアップロードします。</p>
-            </div>
-            <div className="space-y-3 rounded-md border bg-muted/40 p-3 text-xs">
-              <div>
-                <p className="font-medium">テンプレートをダウンロード</p>
-                <p className="text-xs text-muted-foreground">
-                  列構成と入力例を含む CSV をダウンロードし、編集してアップロードしてください。
-                </p>
-                <Button className="mt-2" type="button" onClick={handleTemplateDownload}>
-                  テンプレートをダウンロード
-                </Button>
-                <ul className="text-xs text-muted-foreground list-disc space-y-1 pl-4 mt-2">
-                  {CSV_COLUMNS.map((column) => (
-                    <li key={column.key}>
-                      <span className="font-medium">{column.label}</span>
-                      {column.required ? " (必須)" : ""}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-              <div className="space-y-2">
-                <p className="text-sm font-medium">CSV を選択</p>
-                <p className="text-xs text-muted-foreground">UTF-8 / ヘッダー行付きの CSV を想定しています。</p>
-                <Input ref={fileInputRef} type="file" accept=".csv" onChange={handleFileChange} />
-              </div>
-            </div>
-          </div>
-
-          {importRows.length > 0 ? (
-            <div className="rounded-md border bg-muted/50 p-3 text-xs">
-              <p className="font-medium">解析結果</p>
-              <p>総行数: {importRows.length}</p>
-              <p>検証OK: {summary.ready} / 要カテゴリ確認: {summary.needsMapping} / 取込不可: {summary.invalid}</p>
-              <div className="mt-2 flex gap-2">
-                <Button type="button" size="sm" variant="secondary" onClick={handleStageRows}>
-                  ステージングに送る
-                </Button>
-                <Button type="button" size="sm" variant="ghost" onClick={handleClearUpload}>
-                  クリア
-                </Button>
-              </div>
-            </div>
-          ) : (
-            <p className="text-xs text-muted-foreground">まだファイルは読み込まれていません。</p>
-          )}
-
-          {importRows.length > 0 && (
-            <div className="space-y-3">
-              <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="space-y-4 rounded-md border p-4">
                 <div>
-                  <p className="text-sm font-semibold">プレビュー</p>
-                  <p className="text-xs text-muted-foreground">結果を確認し、ステータスに応じて修正してください。</p>
+                  <p className="text-sm font-medium">商品インポート（CSV）</p>
+                  <p className="text-xs text-muted-foreground">テンプレートで編集した CSV をアップロードします。</p>
                 </div>
-                <div className="flex gap-2 text-xs">
-                  <Badge variant="outline">OK {summary.ready}</Badge>
-                  <Badge variant="outline" className="text-amber-600 border-amber-600">
-                    要確認 {summary.needsMapping}
-                  </Badge>
-                  <Badge variant="outline" className="text-destructive border-destructive">
-                    取込不可 {summary.invalid}
-                  </Badge>
+                <div className="space-y-3 rounded-md border bg-muted/40 p-3 text-xs">
+                  <div>
+                    <p className="font-medium">テンプレートをダウンロード</p>
+                    <p className="text-xs text-muted-foreground">
+                      列構成と入力例を含む CSV をダウンロードし、編集してアップロードしてください。
+                    </p>
+                    <Button className="mt-2" type="button" onClick={handleTemplateDownload}>
+                      テンプレートをダウンロード
+                    </Button>
+                    <ul className="text-xs text-muted-foreground list-disc space-y-1 pl-4 mt-2">
+                      {CSV_COLUMNS.map((column) => (
+                        <li key={column.key}>
+                          <span className="font-medium">{column.label}</span>
+                          {column.required ? " (必須)" : ""}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div className="space-y-2">
+                    <p className="text-sm font-medium">CSV を選択</p>
+                    <p className="text-xs text-muted-foreground">UTF-8 / ヘッダー行付きの CSV を想定しています。</p>
+                    <Input ref={fileInputRef} type="file" accept=".csv" onChange={handleFileChange} />
+                  </div>
                 </div>
               </div>
-              <div className="overflow-x-auto rounded-md border">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead className="w-16">行</TableHead>
-                      <TableHead>商品名</TableHead>
-                      <TableHead>カテゴリ</TableHead>
-                      <TableHead className="text-right">販売価格</TableHead>
-                      <TableHead>ステータス</TableHead>
-                      <TableHead>メモ</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {importRows.map((row) => (
-                      <TableRow key={row.id}>
-                        <TableCell className="text-xs text-muted-foreground">{row.lineNumber}</TableCell>
-                        <TableCell className="font-medium">{row.parsed?.name ?? "-"}</TableCell>
-                        <TableCell className="text-xs text-muted-foreground">{row.parsed?.categoryLabel ?? "-"}</TableCell>
-                        <TableCell className="text-right">
-                          {row.parsed ? row.parsed.salePrice.toLocaleString() : "-"}
-                        </TableCell>
-                        <TableCell>
-                          <Badge variant={row.status === "ready" ? "default" : row.status === "needs_mapping" ? "secondary" : "destructive"}>
-                            {row.status === "ready"
-                              ? "OK"
-                              : row.status === "needs_mapping"
-                                ? "要カテゴリ確認"
-                                : "取込不可"}
-                          </Badge>
-                        </TableCell>
-                        <TableCell className="text-xs text-muted-foreground">
-                          {row.issues.length === 0 ? "-" : row.issues.join(" / ")}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-            </div>
+
+              {importRows.length > 0 ? (
+                <div className="rounded-md border bg-muted/50 p-3 text-xs">
+                  <p className="font-medium">解析結果</p>
+                  <p>総行数: {importRows.length}</p>
+                  <p>検証OK: {summary.ready} / 要カテゴリ確認: {summary.needsMapping} / 取込不可: {summary.invalid}</p>
+                  <div className="mt-2 flex gap-2">
+                    <Button type="button" size="sm" variant="secondary" onClick={handleStageRows}>
+                      ステージングに送る
+                    </Button>
+                    <Button type="button" size="sm" variant="ghost" onClick={handleClearUpload}>
+                      クリア
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-xs text-muted-foreground">まだファイルは読み込まれていません。</p>
+              )}
+
+              {importRows.length > 0 && (
+                <div className="space-y-3">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div>
+                      <p className="text-sm font-semibold">プレビュー</p>
+                      <p className="text-xs text-muted-foreground">結果を確認し、ステータスに応じて修正してください。</p>
+                    </div>
+                    <div className="flex gap-2 text-xs">
+                      <Badge variant="outline">OK {summary.ready}</Badge>
+                      <Badge variant="outline" className="text-amber-600 border-amber-600">
+                        要確認 {summary.needsMapping}
+                      </Badge>
+                      <Badge variant="outline" className="text-destructive border-destructive">
+                        取込不可 {summary.invalid}
+                      </Badge>
+                    </div>
+                  </div>
+                  <div className="overflow-x-auto rounded-md border">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead className="w-16">行</TableHead>
+                          <TableHead>商品名</TableHead>
+                          <TableHead>カテゴリ</TableHead>
+                          <TableHead className="text-right">販売価格</TableHead>
+                          <TableHead>ステータス</TableHead>
+                          <TableHead>メモ</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {importRows.map((row) => (
+                          <TableRow key={row.id}>
+                            <TableCell className="text-xs text-muted-foreground">{row.lineNumber}</TableCell>
+                            <TableCell className="font-medium">{row.parsed?.name ?? "-"}</TableCell>
+                            <TableCell className="text-xs text-muted-foreground">{row.parsed?.categoryLabel ?? "-"}</TableCell>
+                            <TableCell className="text-right">
+                              {row.parsed ? row.parsed.salePrice.toLocaleString() : "-"}
+                            </TableCell>
+                            <TableCell>
+                              <Badge
+                                variant={row.status === "ready" ? "default" : row.status === "needs_mapping" ? "secondary" : "destructive"}
+                              >
+                                {row.status === "ready"
+                                  ? "OK"
+                                  : row.status === "needs_mapping"
+                                    ? "要カテゴリ確認"
+                                    : "取込不可"}
+                              </Badge>
+                            </TableCell>
+                            <TableCell className="text-xs text-muted-foreground">
+                              {row.issues.length === 0 ? "-" : row.issues.join(" / ")}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                </div>
+              )}
+            </>
           )}
         </CardContent>
       </Card>
 
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)]">
+      {showLegacyImport && (
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)]">
         <Card>
           <CardHeader>
             <CardTitle>取り込みステップ</CardTitle>
@@ -833,6 +854,7 @@ export function ProductImportSection({ data, actions }: ProductImportSectionProp
           </Card>
         </div>
       </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## 概要
商品一括インポートの旧フローは残しつつ、デフォルトで非表示にして誤操作を避ける。
管理者用のシート割り当て画面は引き続き表示する。

## 変更点
- 旧インポート（スプレッドシート/CSV/ステップ/ステージング/履歴）をトグル表示に変更
- 管理者用のシート割り当ては常時表示
- 画面説明を「一括同期」利用推奨に変更

## 関連
- #55