### PR TITLE
[不具合修正] ロールバック対象にインポートログも含める

### DIFF
--- a/src/app/api/bulk-sync/rollback/route.ts
+++ b/src/app/api/bulk-sync/rollback/route.ts
@@ -81,7 +81,7 @@ export async function POST(request: Request) {
     const { data: log, error: logError } = await supabase
       .from("sync_audit_logs")
       .select("id, metadata, created_at")
-      .eq("metadata->>action", "bulk_sync_apply")
+      .in("metadata->>action", ["bulk_sync_apply", "bulk_sync_import"])
       .order("created_at", { ascending: false })
       .limit(1)
       .maybeSingle()


### PR DESCRIPTION
## 概要
一括同期の読み込み（`bulk_sync_import`）で更新した後、ロールバックが 404 になるため、
ロールバック対象のログに `bulk_sync_import` も含める。

## 変更点
- `sync_audit_logs` の検索条件を `bulk_sync_apply` + `bulk_sync_import` に拡張

## 期待される効果
- 読み込み（import）後でもロールバックが実行できる
