### PR TITLE
一括処理画面にスプレッドシートを開くボタンを追加

### DIFF
--- a/src/app/_components/bulk/bulk-sync-section.tsx
+++ b/src/app/_components/bulk/bulk-sync-section.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useMemo, useState } from "react"
+import { ExternalLink } from "lucide-react"
 
 import { toast } from "sonner"
 
@@ -72,6 +73,7 @@ export function BulkSyncSection({ title, description, placeholder, helpText, tar
   const [recordAuditLog, setRecordAuditLog] = useState(true)
   const [exportMode, setExportMode] = useState<"overwrite" | "append">("overwrite")
   const [useManualJson, setUseManualJson] = useState(false)
+  const [openingSheet, setOpeningSheet] = useState(false)
 
   const parsedPayload = useMemo(() => parsePayloadJson(payloadInput), [payloadInput])
 
@@ -259,6 +261,35 @@ export function BulkSyncSection({ title, description, placeholder, helpText, tar
     }
   }
 
+  const handleOpenSpreadsheet = async () => {
+    setOpeningSheet(true)
+    try {
+      const headers = await buildAuthHeaders(false)
+      const response = await fetch("/api/bulk-sync/spreadsheet", {
+        method: "GET",
+        headers,
+        credentials: "include",
+      })
+
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({}))
+        throw new Error(error.error ?? "スプレッドシート情報の取得に失敗しました")
+      }
+
+      const data = (await response.json()) as { spreadsheetId?: string }
+      if (!data.spreadsheetId) {
+        throw new Error("スプレッドシートIDが未設定です")
+      }
+
+      const url = `https://docs.google.com/spreadsheets/d/${data.spreadsheetId}/edit`
+      window.open(url, "_blank", "noopener,noreferrer")
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "スプレッドシートを開けませんでした")
+    } finally {
+      setOpeningSheet(false)
+    }
+  }
+
   const statusText =
     busy === "diff"
       ? "差分を確認中..."
@@ -275,7 +306,13 @@ export function BulkSyncSection({ title, description, placeholder, helpText, tar
   return (
     <Card>
       <CardHeader>
-        <CardTitle>{title}</CardTitle>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <CardTitle>{title}</CardTitle>
+          <Button type="button" variant="outline" size="sm" onClick={handleOpenSpreadsheet} disabled={openingSheet}>
+            <ExternalLink className="mr-1 h-4 w-4" />
+            {openingSheet ? "シート確認中..." : "スプレッドシートを開く"}
+          </Button>
+        </div>
         <CardDescription>{description}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">

--- a/src/app/api/bulk-sync/spreadsheet/route.ts
+++ b/src/app/api/bulk-sync/spreadsheet/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server"
+import { cookies } from "next/headers"
+import { createClient } from "@supabase/supabase-js"
+
+export const runtime = "nodejs"
+
+export async function GET(request: Request) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return NextResponse.json({ error: "Supabase env vars missing" }, { status: 500 })
+  }
+
+  let accessToken: string | undefined
+  const authHeader = request.headers.get("authorization")
+  if (authHeader?.toLowerCase().startsWith("bearer ")) {
+    accessToken = authHeader.slice(7)
+  }
+
+  const cookieStore = await cookies()
+  if (!accessToken) {
+    const projectRef = extractProjectRef(supabaseUrl)
+    const cookieName = projectRef ? `sb-${projectRef}-auth-token` : undefined
+    const tokenCookie = cookieName ? cookieStore.get(cookieName) : undefined
+    if (!tokenCookie?.value) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    try {
+      const [access] = JSON.parse(tokenCookie.value)
+      accessToken = access
+    } catch (error) {
+      console.error("Failed to parse Supabase auth cookie", { cookieName, error })
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    if (!accessToken) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+    global: {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+    auth: {
+      persistSession: false,
+    },
+  })
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const { data: sheetSetting, error: sheetError } = await supabase
+    .from("sheet_settings")
+    .select("spreadsheet_id")
+    .eq("user_id", user.id)
+    .maybeSingle()
+
+  if (sheetError && sheetError.code !== "PGRST116") {
+    console.error("Failed to load sheet_settings", sheetError)
+    return NextResponse.json({ error: "Failed to load sheet settings" }, { status: 500 })
+  }
+
+  const spreadsheetId = sheetSetting?.spreadsheet_id ?? process.env.GOOGLE_SHEETS_SPREADSHEET_ID
+  if (!spreadsheetId) {
+    return NextResponse.json({ error: "Sheet settings not found" }, { status: 404 })
+  }
+
+  return NextResponse.json({
+    spreadsheetId,
+    source: sheetSetting?.spreadsheet_id ? "user" : "env",
+  })
+}
+
+const projectRefPattern = /https?:\/\/([a-z0-9-]+)\.supabase\.co/i
+
+function extractProjectRef(url: string) {
+  return url.match(projectRefPattern)?.[1]
+}


### PR DESCRIPTION
## 概要
一括処理画面（BulkSyncSection）に「スプレッドシートを開く」ボタンを追加しました。

## 変更内容
- `GET /api/bulk-sync/spreadsheet` を新規追加
- 認証済みユーザーの `sheet_settings.spreadsheet_id` を取得し、未設定時は `GOOGLE_SHEETS_SPREADSHEET_ID` をフォールバック
- `BulkSyncSection` のカードヘッダーに ExternalLink アイコン付きボタンを追加
- クリック時にスプレッドシートURL（`https://docs.google.com/spreadsheets/d/{id}/edit`）を新規タブで開く処理を実装
- 取得中のローディング表示（`シート確認中...`）を追加
- ID未設定/取得失敗時はトーストでエラーを表示

## 動作確認
- 変更ファイルに対して ESLint 実行
  - `npm run lint -- src/app/_components/bulk/bulk-sync-section.tsx src/app/api/bulk-sync/spreadsheet/route.ts`

Closes #64