### PR TITLE
集計データタブに登録日ベース集計の注記を追加

### DIFF
--- a/src/app/_components/analytics/sections/filter-panel.tsx
+++ b/src/app/_components/analytics/sections/filter-panel.tsx
@@ -29,6 +29,7 @@ export function FilterPanel({
         <CardTitle>可視化フィルタ</CardTitle>
         <CardDescription>期間とカテゴリを切り替えてグラフを更新します。</CardDescription>
         <p className="text-xs text-muted-foreground">対象期間: {currentRangeLabel}</p>
+        <p className="text-xs text-muted-foreground">現在の集計基準は商品登録日です。</p>
       </CardHeader>
       <CardContent>
         <div className="flex flex-col gap-3 md:flex-row md:flex-wrap md:items-center">


### PR DESCRIPTION
## 概要
Issue #71 対応として、集計データタブのフィルターパネルに「登録日ベース集計」であることを明示する注記を追加しました。

## 変更内容
- `src/app/_components/analytics/sections/filter-panel.tsx`
  - ヘッダーに以下の注記を追加
    - `現在の集計基準は商品登録日です。`

## 受け入れ条件への対応
- [x] フィルターパネルに登録日基準である旨の注記が表示される

## 動作確認
- `npm run lint -- src/app/_components/analytics/sections/filter-panel.tsx`

Closes #71