### PR TITLE
マスタ更新時に既存コスト明細への影響件数を通知する

### DIFF
--- a/src/lib/app-data.ts
+++ b/src/lib/app-data.ts
@@ -486,6 +486,10 @@ export function useAppData() {
   )
 
   const updateMaterial = useCallback((input: Material) => {
+    const affected = dataRef.current.costEntries.materials.filter((entry) => entry.materialId === input.id).length
+    if (affected > 0) {
+      toast.info(`コスト明細 ${affected} 件が「${input.name}」を参照しています。単価は自動更新されません。`)
+    }
     update((prev) => ({
       ...prev,
       materials: prev.materials.map((material) => (material.id === input.id ? input : material)),
@@ -515,6 +519,10 @@ export function useAppData() {
   )
 
   const updatePackagingItem = useCallback((input: PackagingItem) => {
+    const affected = dataRef.current.costEntries.packaging.filter((entry) => entry.packagingItemId === input.id).length
+    if (affected > 0) {
+      toast.info(`コスト明細 ${affected} 件が「${input.name}」を参照しています。単価は自動更新されません。`)
+    }
     update((prev) => ({
       ...prev,
       packagingItems: prev.packagingItems.map((item) => (item.id === input.id ? input : item)),
@@ -544,6 +552,10 @@ export function useAppData() {
   )
 
   const updateShippingMethod = useCallback((input: ShippingMethod) => {
+    const affected = dataRef.current.costEntries.logistics.filter((entry) => entry.shippingMethodId === input.id).length
+    if (affected > 0) {
+      toast.info(`コスト明細 ${affected} 件が「${input.name}」を参照しています。単価は自動更新されません。`)
+    }
     update((prev) => ({
       ...prev,
       shippingMethods: (prev.shippingMethods ?? []).map((method) => (method.id === input.id ? input : method)),
@@ -570,6 +582,10 @@ export function useAppData() {
   )
 
   const updateLaborRole = useCallback((input: LaborRole) => {
+    const affected = dataRef.current.costEntries.labor.filter((entry) => entry.laborRoleId === input.id).length
+    if (affected > 0) {
+      toast.info(`コスト明細 ${affected} 件が「${input.name}」を参照しています。時給は自動更新されません。`)
+    }
     update((prev) => ({
       ...prev,
       laborRoles: prev.laborRoles.map((role) => (role.id === input.id ? input : role)),
@@ -631,6 +647,10 @@ export function useAppData() {
   )
 
   const updateEquipment = useCallback((input: Equipment) => {
+    const affected = dataRef.current.costEntries.equipmentAllocations.filter((entry) => entry.equipmentId === input.id).length
+    if (affected > 0) {
+      toast.info(`コスト明細 ${affected} 件が「${input.name}」を参照しています。償却コストは自動更新されません。`)
+    }
     update((prev) => ({
       ...prev,
       equipments: prev.equipments.map((equipment) => (equipment.id === input.id ? input : equipment)),
@@ -661,6 +681,10 @@ export function useAppData() {
   )
 
   const updateFee = useCallback((input: Fee) => {
+    const affected = dataRef.current.costEntries.fees.filter((entry) => entry.feeId === input.id).length
+    if (affected > 0) {
+      toast.info(`コスト明細 ${affected} 件が「${input.name}」を参照しています。手数料は自動更新されません。`)
+    }
     update((prev) => ({
       ...prev,
       fees: prev.fees.map((fee) => (fee.id === input.id ? input : fee)),


### PR DESCRIPTION
closes #75

## 概要

材料・梱包材・人件費ロール・設備・配送方法・手数料の各マスタ更新時に、そのマスタを参照しているコスト明細の件数を `toast.info` で通知するようにしました。

## 変更内容

`src/lib/app-data.ts` の以下の関数を修正:

| 関数 | 参照先 | 通知文言 |
|---|---|---|
| `updateMaterial` | `costEntries.materials` | 単価は自動更新されません |
| `updatePackagingItem` | `costEntries.packaging` | 単価は自動更新されません |
| `updateLaborRole` | `costEntries.labor` | 時給は自動更新されません |
| `updateEquipment` | `costEntries.equipmentAllocations` | 償却コストは自動更新されません |
| `updateShippingMethod` | `costEntries.logistics` | 単価は自動更新されません |
| `updateFee` | `costEntries.fees` | 手数料は自動更新されません |

- 参照件数が 0 の場合は通知しない
- `dataRef.current` で更新前の最新データを参照し、React Strict Mode の state updater 二重呼び出しによる二重 toast を回避

## 受け入れ条件チェック

- [x] マスタ更新時に、参照中コスト明細が N 件あることを toast で通知する

🤖 Generated with [Claude Code](https://claude.com/claude-code)