### PR TITLE
商品タブの登録済み商品一覧で在庫増減を操作できるように対応

### DIFF
--- a/src/app/_components/product/product-tab.tsx
+++ b/src/app/_components/product/product-tab.tsx
@@ -10,6 +10,7 @@ interface ProductTabProps {
   data: AppData
   actions: AppActions
   stocks: Map<string, number>
+  stocksLoaded: boolean
   isAuthenticated: boolean
   onAdjustStock: (productId: string, delta: number) => Promise<void>
   onSetStock: (productId: string, quantity: number) => Promise<void>
@@ -20,7 +21,7 @@ interface ProductTabProps {
 }
 
 export function ProductTab(props: ProductTabProps) {
-  const { data, stocks, isAuthenticated, onAdjustStock, onSetStock } = props
+  const { data, stocks, stocksLoaded, isAuthenticated, onAdjustStock, onSetStock } = props
 
   return (
     <div className="space-y-6">
@@ -28,6 +29,7 @@ export function ProductTab(props: ProductTabProps) {
       <RegisteredProductsSection
         data={data}
         stocks={stocks}
+        stocksLoaded={stocksLoaded}
         isAuthenticated={isAuthenticated}
         onAdjust={onAdjustStock}
         onSet={onSetStock}

--- a/src/app/_components/product/sections/registered-products-section.tsx
+++ b/src/app/_components/product/sections/registered-products-section.tsx
@@ -13,12 +13,20 @@ import { toast } from "sonner"
 interface RegisteredProductsSectionProps {
   data: AppData
   stocks: Map<string, number>
+  stocksLoaded: boolean
   isAuthenticated: boolean
   onAdjust: (productId: string, delta: number) => Promise<void>
   onSet: (productId: string, quantity: number) => Promise<void>
 }
 
-export function RegisteredProductsSection({ data, stocks, isAuthenticated, onAdjust, onSet }: RegisteredProductsSectionProps) {
+export function RegisteredProductsSection({
+  data,
+  stocks,
+  stocksLoaded,
+  isAuthenticated,
+  onAdjust,
+  onSet,
+}: RegisteredProductsSectionProps) {
   const [adjustAmounts, setAdjustAmounts] = useState<Map<string, string>>(new Map())
   const [busy, setBusy] = useState<string | null>(null)
   const [editingStock, setEditingStock] = useState<{ productId: string; value: string } | null>(null)
@@ -121,6 +129,8 @@ export function RegisteredProductsSection({ data, stocks, isAuthenticated, onAdj
                     <TableCell className="text-right">
                       {!isAuthenticated ? (
                         "-"
+                      ) : !stocksLoaded ? (
+                        "..."
                       ) : isEditing ? (
                         <div className="flex items-center justify-end gap-1">
                           <Input
@@ -156,20 +166,23 @@ export function RegisteredProductsSection({ data, stocks, isAuthenticated, onAdj
                       )}
                     </TableCell>
                     <TableCell>
-                      <Input
-                        type="number"
-                        min={1}
-                        value={adjustAmounts.get(product.id) ?? "1"}
-                        onChange={(event) =>
-                          setAdjustAmounts((prev) => {
-                            const next = new Map(prev)
-                            next.set(product.id, event.target.value)
-                            return next
-                          })
-                        }
-                        className="h-8 w-20"
-                        disabled={!isAuthenticated}
-                      />
+                      {isAuthenticated ? (
+                        <Input
+                          type="number"
+                          min={1}
+                          value={adjustAmounts.get(product.id) ?? "1"}
+                          onChange={(event) =>
+                            setAdjustAmounts((prev) => {
+                              const next = new Map(prev)
+                              next.set(product.id, event.target.value)
+                              return next
+                            })
+                          }
+                          className="h-8 w-20"
+                        />
+                      ) : (
+                        "-"
+                      )}
                     </TableCell>
                     <TableCell>
                       {isAuthenticated ? (
@@ -186,7 +199,7 @@ export function RegisteredProductsSection({ data, stocks, isAuthenticated, onAdj
                             size="sm"
                             variant="outline"
                             onClick={() => handleUse(product.id)}
-                            disabled={isBusy || isEditing || quantity === 0}
+                            disabled={isBusy || isEditing || !stocksLoaded || quantity === 0}
                           >
                             −使用
                           </Button>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -791,6 +791,7 @@ export default function Home() {
             data={data}
             actions={actions}
             stocks={stocks}
+            stocksLoaded={stocksLoaded}
             isAuthenticated={isAuthenticated}
             onAdjustStock={adjustStock}
             onSetStock={setStock}


### PR DESCRIPTION
## 概要
- 商品タブの登録済み商品テーブルに「現在庫数」列を追加
- 在庫数の直接編集（クリックで編集→確定）を追加
- 「増減量」入力と「+追加 / −使用」ボタンを追加
- 未ログイン時は在庫数を `-` 表示、在庫操作ボタンは非表示
- `ProductTab` と `page.tsx` で在庫操作用 props を受け渡し

## 変更ファイル
- `src/app/_components/product/sections/registered-products-section.tsx`
- `src/app/_components/product/product-tab.tsx`
- `src/app/page.tsx`

## 動作確認
- `npm run build`

Closes #101