### PR TITLE
マスタ在庫単位をスプレッドシート書き出しに含める

### DIFF
--- a/src/app/_components/bulk/bulk-sync-section.tsx
+++ b/src/app/_components/bulk/bulk-sync-section.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useState } from "react"
 import { ExternalLink, History } from "lucide-react"
-
 import { toast } from "sonner"
 
 import { Badge } from "@/components/ui/badge"

--- a/src/app/api/bulk-sync/export/route.ts
+++ b/src/app/api/bulk-sync/export/route.ts
@@ -103,22 +103,32 @@ export async function POST(request: Request) {
   try {
     const [appData, materialStocksResult, packagingStocksResult, productStocksResult] = await Promise.all([
       loadUserAppDataServer(supabase, user.id),
-      supabase.from("material_stock").select("material_id, quantity").eq("user_id", user.id),
-      supabase.from("packaging_stock").select("packaging_item_id, quantity").eq("user_id", user.id),
+      supabase.from("material_stock").select("material_id, quantity, stock_unit").eq("user_id", user.id),
+      supabase.from("packaging_stock").select("packaging_item_id, quantity, stock_unit").eq("user_id", user.id),
       supabase.from("product_stock").select("product_id, quantity").eq("user_id", user.id),
     ])
 
     const materialStocks = new Map(
       (materialStocksResult.data ?? []).map((r) => [r.material_id as string, Number(r.quantity)])
     )
+    const materialStockUnits = new Map(
+      (materialStocksResult.data ?? [])
+        .filter((r) => r.stock_unit)
+        .map((r) => [r.material_id as string, r.stock_unit as string])
+    )
     const packagingStocks = new Map(
       (packagingStocksResult.data ?? []).map((r) => [r.packaging_item_id as string, Number(r.quantity)])
+    )
+    const packagingStockUnits = new Map(
+      (packagingStocksResult.data ?? [])
+        .filter((r) => r.stock_unit)
+        .map((r) => [r.packaging_item_id as string, r.stock_unit as string])
     )
     const productStocks = new Map(
       (productStocksResult.data ?? []).map((r) => [r.product_id as string, Number(r.quantity)])
     )
 
-    const sheetRows = buildBulkSyncSheetRows(appData, { materialStocks, packagingStocks, productStocks })
+    const sheetRows = buildBulkSyncSheetRows(appData, { materialStocks, materialStockUnits, packagingStocks, packagingStockUnits, productStocks })
 
     const targets: (keyof typeof sheetRows)[] =
       body.target === "master"

--- a/src/lib/bulk-sync/sheet-columns.ts
+++ b/src/lib/bulk-sync/sheet-columns.ts
@@ -29,6 +29,7 @@ export const SHEET_COLUMNS: Record<BulkSyncEntity, string[]> = {
     "supplier",
     "note",
     "stock",
+    "stock_unit",
     "is_deleted",
   ],
   packaging_items: [
@@ -41,6 +42,7 @@ export const SHEET_COLUMNS: Record<BulkSyncEntity, string[]> = {
     "units_per_batch",
     "note",
     "stock",
+    "stock_unit",
     "is_deleted",
   ],
   shipping_methods: ["id", "name", "description", "unit_cost", "currency", "note", "is_deleted"],

--- a/src/lib/bulk-sync/sheet-export.ts
+++ b/src/lib/bulk-sync/sheet-export.ts
@@ -13,7 +13,9 @@ const serializeVariants = (variants: ProductSizeVariant[]) => {
 
 type StockMaps = {
   materialStocks?: Map<string, number>
+  materialStockUnits?: Map<string, string>
   packagingStocks?: Map<string, number>
+  packagingStockUnits?: Map<string, string>
   productStocks?: Map<string, number>
 }
 
@@ -59,6 +61,7 @@ export const buildBulkSyncSheetRows = (data: AppData, stocks?: StockMaps) => {
       item.supplier ?? "",
       item.note ?? "",
       stocks?.materialStocks?.get(item.id) ?? "",
+      stocks?.materialStockUnits?.get(item.id) ?? "",
       "",
     ]),
     packaging_items: data.packagingItems.map((item) => [
@@ -71,6 +74,7 @@ export const buildBulkSyncSheetRows = (data: AppData, stocks?: StockMaps) => {
       item.unitsPerBatch ?? "",
       item.note ?? "",
       stocks?.packagingStocks?.get(item.id) ?? "",
+      stocks?.packagingStockUnits?.get(item.id) ?? "",
       "",
     ]),
     shipping_methods: data.shippingMethods.map((item) => [


### PR DESCRIPTION
- sheet-columns: materials/packaging_itemsにstock_unitカラムを追加
- sheet-export: StockMapsにstockUnitsを追加し、行データに含める
- export/route: stock_unitをSELECTして書き出しに渡す