### PR TITLE
マスタ在庫単位(stock_unit)のスプシ連携を追加

### DIFF
--- a/src/lib/bulk-sync/apply.ts
+++ b/src/lib/bulk-sync/apply.ts
@@ -19,7 +19,7 @@ export type BulkSyncApplySummary = DiffSummary & {
   failed: number
 }
 
-export type StockUpsert = { id: string; quantity: number }
+export type StockUpsert = { id: string; quantity: number; stockUnit?: string }
 
 export type BulkSyncApplyResult = {
   payload: Record<string, unknown>
@@ -399,7 +399,10 @@ export const prepareBulkSyncApply = (
         })
         if (id) {
           const stock = getNumber(record.data.stock)
-          if (stock !== undefined && stock >= 0) stockUpserts.materials.push({ id, quantity: stock })
+          const stockUnit = typeof record.data.stock_unit === "string" ? record.data.stock_unit : undefined
+          if (stock !== undefined && stock >= 0) {
+            stockUpserts.materials.push({ id, quantity: stock, stockUnit })
+          }
         }
         if (resolvedId) updateCount += 1
         else createCount += 1
@@ -417,7 +420,10 @@ export const prepareBulkSyncApply = (
         })
         if (id) {
           const stock = getNumber(record.data.stock)
-          if (stock !== undefined && stock >= 0) stockUpserts.packagingItems.push({ id, quantity: stock })
+          const stockUnit = typeof record.data.stock_unit === "string" ? record.data.stock_unit : undefined
+          if (stock !== undefined && stock >= 0) {
+            stockUpserts.packagingItems.push({ id, quantity: stock, stockUnit })
+          }
         }
         if (resolvedId) updateCount += 1
         else createCount += 1

--- a/src/lib/bulk-sync/validation.ts
+++ b/src/lib/bulk-sync/validation.ts
@@ -344,6 +344,7 @@ export const validateBulkSyncPayload = (payload: BulkSyncPayload, existing: AppD
     }
 
     const materialStock = asNumber(item.stock)
+    const materialStockUnit = asOptionalString(item.stock_unit)
 
     pushRecord({
       entity: "materials",
@@ -360,6 +361,7 @@ export const validateBulkSyncPayload = (payload: BulkSyncPayload, existing: AppD
         supplier,
         note: asOptionalString(item.note),
         stock: Number.isFinite(materialStock) ? materialStock : undefined,
+        stock_unit: materialStockUnit,
       },
       rowIndex: index,
     })
@@ -387,6 +389,7 @@ export const validateBulkSyncPayload = (payload: BulkSyncPayload, existing: AppD
     }
 
     const packagingStock = asNumber(item.stock)
+    const packagingStockUnit = asOptionalString(item.stock_unit)
 
     pushRecord({
       entity: "packaging_items",
@@ -402,6 +405,7 @@ export const validateBulkSyncPayload = (payload: BulkSyncPayload, existing: AppD
         units_per_batch: Number.isFinite(unitsPerBatch) ? unitsPerBatch : undefined,
         note: asOptionalString(item.note),
         stock: Number.isFinite(packagingStock) ? packagingStock : undefined,
+        stock_unit: packagingStockUnit,
       },
       rowIndex: index,
     })

--- a/src/lib/server/apply-stock-upserts.ts
+++ b/src/lib/server/apply-stock-upserts.ts
@@ -9,16 +9,31 @@ export async function applyStockUpserts(
 ) {
   const now = new Date().toISOString()
   const results = await Promise.allSettled([
-    ...stockUpserts.materials.map(({ id, quantity }) =>
+    ...stockUpserts.materials.map(({ id, quantity, stockUnit }) =>
       supabase
         .from("material_stock")
-        .upsert({ user_id: userId, material_id: id, quantity, updated_at: now }, { onConflict: "user_id,material_id" })
+        .upsert(
+          {
+            user_id: userId,
+            material_id: id,
+            quantity,
+            updated_at: now,
+            ...(stockUnit !== undefined ? { stock_unit: stockUnit || null } : {}),
+          },
+          { onConflict: "user_id,material_id" }
+        )
     ),
-    ...stockUpserts.packagingItems.map(({ id, quantity }) =>
+    ...stockUpserts.packagingItems.map(({ id, quantity, stockUnit }) =>
       supabase
         .from("packaging_stock")
         .upsert(
-          { user_id: userId, packaging_item_id: id, quantity, updated_at: now },
+          {
+            user_id: userId,
+            packaging_item_id: id,
+            quantity,
+            updated_at: now,
+            ...(stockUnit !== undefined ? { stock_unit: stockUnit || null } : {}),
+          },
           { onConflict: "user_id,packaging_item_id" }
         )
     ),


### PR DESCRIPTION
## Summary
- スプレッドシート書き出し時に`stock_unit`カラムを含める
- スプレッドシート読み込み時に`stock_unit`をDBに反映する

## 変更ファイル
- `sheet-columns.ts`: materials/packaging_itemsに`stock_unit`カラム追加
- `sheet-export.ts`: 書き出し時にstock_unitを含める
- `export/route.ts`: DBからstock_unitを取得して渡す
- `validation.ts`: 読み込み時にstock_unitをパース
- `apply.ts`: StockUpsertにstockUnitを追加
- `apply-stock-upserts.ts`: upsert時にstock_unitを保存

## 前提
本番Supabaseに以下のマイグレーションが適用されている必要があります：
```sql
alter table material_stock add column if not exists stock_unit text;
alter table packaging_stock add column if not exists stock_unit text;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)