### PR TITLE
マスタ一覧の在庫増減ボタンラベルを + / − に短縮

### DIFF
--- a/src/app/_components/master/sections/material/material-list-section.tsx
+++ b/src/app/_components/master/sections/material/material-list-section.tsx
@@ -369,19 +369,21 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
                               type="button"
                               size="sm"
                               variant="outline"
+                              title="追加"
                               onClick={() => handleAdd(material)}
                               disabled={(busy?.startsWith(material.id) ?? false) || editingStock?.id === material.id || editingMaterial.id === material.id}
                             >
-                              +追加
+                              +
                             </Button>
                             <Button
                               type="button"
                               size="sm"
                               variant="outline"
+                              title="使用（減算）"
                               onClick={() => handleUse(material)}
                               disabled={(busy?.startsWith(material.id) ?? false) || editingStock?.id === material.id || editingMaterial.id === material.id || (materialStocks.get(material.id) ?? 0) === 0}
                             >
-                              −使用
+                              −
                             </Button>
                           </div>
                         )}

--- a/src/app/_components/master/sections/packaging/packaging-list-section.tsx
+++ b/src/app/_components/master/sections/packaging/packaging-list-section.tsx
@@ -365,19 +365,21 @@ export function PackagingListSection({ data, actions, createTempId, isAuthentica
                               type="button"
                               size="sm"
                               variant="outline"
+                              title="追加"
                               onClick={() => handleAdd(item)}
                               disabled={(busy?.startsWith(item.id) ?? false) || editingStock?.id === item.id || editingPackaging.id === item.id}
                             >
-                              +追加
+                              +
                             </Button>
                             <Button
                               type="button"
                               size="sm"
                               variant="outline"
+                              title="使用（減算）"
                               onClick={() => handleUse(item)}
                               disabled={(busy?.startsWith(item.id) ?? false) || editingStock?.id === item.id || editingPackaging.id === item.id || (packagingStocks.get(item.id) ?? 0) === 0}
                             >
-                              −使用
+                              −
                             </Button>
                           </div>
                         )}


### PR DESCRIPTION
## 概要
- 材料一覧・梱包材一覧の在庫増減ボタンラベルを `+追加` / `−使用` から `+` / `−` に変更
- 各ボタンに `title` 属性を追加して意味を補完
  - `+` ボタン: `title="追加"`
  - `−` ボタン: `title="使用（減算）"`
- disabled 条件・在庫増減ロジックは既存のまま維持

## 変更ファイル
- `src/app/_components/master/sections/material/material-list-section.tsx`
- `src/app/_components/master/sections/packaging/packaging-list-section.tsx`

## 動作確認
- `npm run build`

Closes #112