### PR TITLE
マスタ一覧テーブルの列幅を圧縮して横スクロールを解消

### DIFF
--- a/src/app/_components/master/sections/material/material-list-section.tsx
+++ b/src/app/_components/master/sections/material/material-list-section.tsx
@@ -176,7 +176,7 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
           <p className="text-sm text-muted-foreground">まだ登録がありません。</p>
         ) : (
           <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
-            <Table className="min-w-[1100px]">
+            <Table className="min-w-[980px]">
               <TableHeader>
                 <TableRow>
                   <TableHead>名称</TableHead>
@@ -188,7 +188,7 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
                   <TableHead>現在残数</TableHead>
                   <TableHead>増減量</TableHead>
                   <TableHead></TableHead>
-                  <TableHead className="w-48 text-right">
+                  <TableHead className="w-40 text-right">
                     <span className="sr-only">操作</span>
                   </TableHead>
                 </TableRow>
@@ -206,7 +206,9 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
                             onChange={(event) => setEditingMaterial((prev) => ({ ...prev, name: event.target.value }))}
                           />
                         ) : (
-                          material.name
+                          <span className="block max-w-[140px] truncate" title={material.name}>
+                            {material.name}
+                          </span>
                         )}
                       </TableCell>
                       <TableCell>
@@ -268,7 +270,13 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
                             onChange={(event) => setEditingMaterial((prev) => ({ ...prev, supplier: event.target.value }))}
                           />
                         ) : (
-                          material.supplier || "-"
+                          material.supplier ? (
+                            <span className="block max-w-[100px] truncate" title={material.supplier}>
+                              {material.supplier}
+                            </span>
+                          ) : (
+                            "-"
+                          )
                         )}
                       </TableCell>
                       <TableCell>
@@ -278,7 +286,13 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
                             onChange={(event) => setEditingMaterial((prev) => ({ ...prev, note: event.target.value }))}
                           />
                         ) : (
-                          material.note || "-"
+                          material.note ? (
+                            <span className="block max-w-[120px] truncate" title={material.note}>
+                              {material.note}
+                            </span>
+                          ) : (
+                            "-"
+                          )
                         )}
                       </TableCell>
                       <TableCell>
@@ -298,7 +312,7 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
                                     : { id: material.id, value: e.target.value, unit: displayStockUnit }
                                 )
                               }
-                              className="h-8 w-24"
+                              className="h-8 w-20"
                             />
                             <Input
                               value={editingStock.unit}
@@ -309,7 +323,7 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
                                     : { id: material.id, value: String(materialStocks.get(material.id) ?? 0), unit: e.target.value }
                                 )
                               }
-                              className="h-8 w-20"
+                              className="h-8 w-16"
                               placeholder="単位"
                             />
                             <Button
@@ -358,7 +372,7 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
                                 return next
                               })
                             }
-                            className="h-8 w-20"
+                            className="h-8 w-16"
                           />
                         )}
                       </TableCell>
@@ -369,6 +383,7 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
                               type="button"
                               size="sm"
                               variant="outline"
+                              className="h-8 w-8 px-0"
                               title="追加"
                               onClick={() => handleAdd(material)}
                               disabled={(busy?.startsWith(material.id) ?? false) || editingStock?.id === material.id || editingMaterial.id === material.id}
@@ -379,6 +394,7 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
                               type="button"
                               size="sm"
                               variant="outline"
+                              className="h-8 w-8 px-0"
                               title="使用（減算）"
                               onClick={() => handleUse(material)}
                               disabled={(busy?.startsWith(material.id) ?? false) || editingStock?.id === material.id || editingMaterial.id === material.id || (materialStocks.get(material.id) ?? 0) === 0}

--- a/src/app/_components/master/sections/packaging/packaging-list-section.tsx
+++ b/src/app/_components/master/sections/packaging/packaging-list-section.tsx
@@ -172,7 +172,7 @@ export function PackagingListSection({ data, actions, createTempId, isAuthentica
           <p className="text-sm text-muted-foreground">まだ登録がありません。</p>
         ) : (
           <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
-            <Table className="min-w-[1100px]">
+            <Table className="min-w-[980px]">
               <TableHeader>
                 <TableRow>
                   <TableHead>名称</TableHead>
@@ -184,7 +184,7 @@ export function PackagingListSection({ data, actions, createTempId, isAuthentica
                   <TableHead>現在残数</TableHead>
                   <TableHead>増減量</TableHead>
                   <TableHead></TableHead>
-                  <TableHead className="w-48 text-right">
+                  <TableHead className="w-40 text-right">
                     <span className="sr-only">操作</span>
                   </TableHead>
                 </TableRow>
@@ -202,7 +202,9 @@ export function PackagingListSection({ data, actions, createTempId, isAuthentica
                             onChange={(event) => setEditingPackaging((prev) => ({ ...prev, name: event.target.value }))}
                           />
                         ) : (
-                          item.name
+                          <span className="block max-w-[140px] truncate" title={item.name}>
+                            {item.name}
+                          </span>
                         )}
                       </TableCell>
                       <TableCell>
@@ -264,7 +266,13 @@ export function PackagingListSection({ data, actions, createTempId, isAuthentica
                             onChange={(event) => setEditingPackaging((prev) => ({ ...prev, sizeDescription: event.target.value }))}
                           />
                         ) : (
-                          item.sizeDescription || "-"
+                          item.sizeDescription ? (
+                            <span className="block max-w-[120px] truncate" title={item.sizeDescription}>
+                              {item.sizeDescription}
+                            </span>
+                          ) : (
+                            "-"
+                          )
                         )}
                       </TableCell>
                       <TableCell>
@@ -274,7 +282,13 @@ export function PackagingListSection({ data, actions, createTempId, isAuthentica
                             onChange={(event) => setEditingPackaging((prev) => ({ ...prev, note: event.target.value }))}
                           />
                         ) : (
-                          item.note || "-"
+                          item.note ? (
+                            <span className="block max-w-[120px] truncate" title={item.note}>
+                              {item.note}
+                            </span>
+                          ) : (
+                            "-"
+                          )
                         )}
                       </TableCell>
                       <TableCell>
@@ -294,7 +308,7 @@ export function PackagingListSection({ data, actions, createTempId, isAuthentica
                                     : { id: item.id, value: e.target.value, unit: displayStockUnit }
                                 )
                               }
-                              className="h-8 w-24"
+                              className="h-8 w-20"
                             />
                             <Input
                               value={editingStock.unit}
@@ -305,7 +319,7 @@ export function PackagingListSection({ data, actions, createTempId, isAuthentica
                                     : { id: item.id, value: String(packagingStocks.get(item.id) ?? 0), unit: e.target.value }
                                 )
                               }
-                              className="h-8 w-20"
+                              className="h-8 w-16"
                               placeholder="単位"
                             />
                             <Button
@@ -354,7 +368,7 @@ export function PackagingListSection({ data, actions, createTempId, isAuthentica
                                 return next
                               })
                             }
-                            className="h-8 w-20"
+                            className="h-8 w-16"
                           />
                         )}
                       </TableCell>
@@ -365,6 +379,7 @@ export function PackagingListSection({ data, actions, createTempId, isAuthentica
                               type="button"
                               size="sm"
                               variant="outline"
+                              className="h-8 w-8 px-0"
                               title="追加"
                               onClick={() => handleAdd(item)}
                               disabled={(busy?.startsWith(item.id) ?? false) || editingStock?.id === item.id || editingPackaging.id === item.id}
@@ -375,6 +390,7 @@ export function PackagingListSection({ data, actions, createTempId, isAuthentica
                               type="button"
                               size="sm"
                               variant="outline"
+                              className="h-8 w-8 px-0"
                               title="使用（減算）"
                               onClick={() => handleUse(item)}
                               disabled={(busy?.startsWith(item.id) ?? false) || editingStock?.id === item.id || editingPackaging.id === item.id || (packagingStocks.get(item.id) ?? 0) === 0}


### PR DESCRIPTION
## 概要
- 材料/梱包材テーブルの最小幅を `min-w-[1100px]` から `min-w-[980px]` へ見直し
- 増減量入力・在庫編集入力の幅を縮小（`w-20`/`w-24` を圧縮）
- `+` / `−` ボタンを小型化（`h-8 w-8 px-0`）
- 長文になりやすい名称・仕入先/仕様・備考を `truncate` で省略表示し、列幅の肥大化を抑制
- 横スクロールコンテナ（`overflow-x-auto`）は維持

## 変更ファイル
- `src/app/_components/master/sections/material/material-list-section.tsx`
- `src/app/_components/master/sections/packaging/packaging-list-section.tsx`

## 動作確認
- `npm run build`

Closes #113