### PR TITLE
梱包材削除後にリロードで復活するバグを修正（TOKEN_REFRESHED レース条件）

### DIFF
--- a/src/lib/app-data.ts
+++ b/src/lib/app-data.ts
@@ -149,6 +149,9 @@ export function useAppData() {
   const [remoteLoadCompleted, setRemoteLoadCompleted] = useState(authState.status !== "authenticated")
   const [remoteLoadFailed, setRemoteLoadFailed] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
+  // Stable primitives derived from authState — used as deps instead of the full object
+  // to prevent load effect re-runs when only the object reference changes (e.g. TOKEN_REFRESHED).
+  const authUserId = authState.status === "authenticated" ? authState.user.id : null
   const authStatusRef = useRef<AuthState["status"]>(authState.status)
   const previousAuthStatus = authStatusRef.current
   const saveRetryRef = useRef<{ attempts: number; timeoutId: ReturnType<typeof setTimeout> | null }>({ attempts: 0, timeoutId: null })
@@ -162,10 +165,10 @@ export function useAppData() {
   }, [])
 
   const refreshAuditLogs = useCallback(async () => {
-    if (authState.status !== "authenticated") return
+    if (!authUserId) return
     setAuditLogsLoading(true)
     try {
-      const logs = await loadAuditLogs(authState.user.id, 50, 0, auditFilters)
+      const logs = await loadAuditLogs(authUserId, 50, 0, auditFilters)
       auditLogsIndexRef.current = logs.length
       setAuditLogs(logs)
       setAuditHasMore(logs.length === 50)
@@ -174,7 +177,7 @@ export function useAppData() {
     } finally {
       setAuditLogsLoading(false)
     }
-  }, [authState, auditFilters])
+  }, [authUserId, auditFilters])
 
   const loadMoreAuditLogs = useCallback(async () => {
     if (authState.status !== "authenticated") return
@@ -486,7 +489,7 @@ export function useAppData() {
 
   useEffect(() => {
     if (!hydrated) return
-    if (authState.status !== "authenticated") {
+    if (!authUserId) {
       setRemoteLoadCompleted(true)
       setRemoteLoadFailed(false)
       return
@@ -496,7 +499,7 @@ export function useAppData() {
     setRemoteLoadFailed(false)
     ;(async () => {
       try {
-        const remote = await loadUserAppData(authState.user.id)
+        const remote = await loadUserAppData(authUserId)
         if (cancelled) return
         if (!remote) {
           setRemoteLoadFailed(false)
@@ -526,7 +529,7 @@ export function useAppData() {
     return () => {
       cancelled = true
     }
-  }, [authState, hydrated, clearSaveRetry, refreshAuditLogs])
+  }, [authUserId, hydrated, clearSaveRetry, refreshAuditLogs])
 
   useEffect(() => {
     if (!hydrated || !remoteLoadCompleted) return

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -69,8 +69,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
     }
     void init()
-    const { data: subscription } = supabaseClient.auth.onAuthStateChange((_event, session) => {
+    const { data: subscription } = supabaseClient.auth.onAuthStateChange((event, session) => {
       if (!mounted) return
+      // TOKEN_REFRESHED only refreshes the JWT silently — the user identity doesn't change.
+      // Skipping it avoids unnecessary authState object re-creation, which would otherwise
+      // trigger a full DB reload in useAppData and risk a race condition with in-flight saves.
+      if (event === "TOKEN_REFRESHED") return
       if (session?.user) {
         void fetchProfile(session.user.id, session.user.email ?? "")
       } else {


### PR DESCRIPTION
## 問題

梱包材を削除すると成功トーストが表示されるが、ページをリロードすると削除した梱包材が復活する。DBからは消えているが、リロードで再び現れる。

## 根本原因

レース条件（auth イベント起因の DB 二重ロード）:

1. `removePackagingItem` → `persistSupabaseWithRetry()` → 非同期で RPC 呼び出し（トランザクション未コミット）
2. Supabase SDK が `TOKEN_REFRESHED` イベントを発火
3. `onAuthStateChange` が `_event` を無視して `fetchProfile` を呼び出し → `setState(new authState object)`
4. `authState` のオブジェクト参照が変わる → `refreshAuditLogs` が再生成 → DB ロードエフェクトが再実行
5. `loadUserAppData` が実行されるが、削除トランザクションはまだ未コミット
6. READ COMMITTED 分離レベルにより削除前のデータを読み込み、`lastSyncedDataRef` を上書き
7. トランザクションがコミット → DBから削除完了
8. 以降の保存で `buildSyncPayload(current, lastSynced)` の差分が 0 になり、削除されたアイテムが再度 UPSERT される

## 修正内容

### `auth.tsx`（根本原因の修正）
- `TOKEN_REFRESHED` イベントは JWT をサイレントに更新するだけでユーザー ID は変わらない
- このイベントをスキップすることで不要な `authState` オブジェクト再生成を防止

### `app-data.ts`（防御的対処）
- DB ロードエフェクトと `refreshAuditLogs` の依存配列を `authState` オブジェクト全体から、安定したプリミティブ `authUserId: string | null` に変更
- オブジェクト参照変化だけではエフェクトが再実行されないよう改善

## テスト方法

1. 梱包材を削除
2. 成功トーストを確認
3. ページをリロード → 削除した梱包材が復活しないことを確認
4. ブラウザの開発者ツールで TOKEN_REFRESHED イベント発火後もデータが正常であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)