### PR TITLE
Issue #123 商品一覧のカラムカスタマイズ機能

### DIFF
--- a/src/app/_components/product-list/customizable-product-table.tsx
+++ b/src/app/_components/product-list/customizable-product-table.tsx
@@ -1,0 +1,338 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { Copy, Edit3, GripVertical, Trash2 } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { formatCurrency } from "@/lib/calculations"
+import type { Product } from "@/lib/types"
+
+export const CUSTOMIZABLE_PRODUCT_COLUMNS = [
+  "category",
+  "options",
+  "shipping",
+  "equipment",
+  "productionLotSize",
+  "expectedProduction",
+  "salePrice",
+  "profit",
+  "notes",
+] as const
+
+export type CustomizableProductColumnKey = (typeof CUSTOMIZABLE_PRODUCT_COLUMNS)[number]
+
+type ProductListEntry = {
+  product: Product
+  salePrice: number
+  profit: number
+  categoryPath: string
+  shippingText: string
+  equipmentText: string
+}
+
+export type ProductTableColumnSettings = {
+  columnOrder: CustomizableProductColumnKey[]
+  hiddenColumns: CustomizableProductColumnKey[]
+}
+
+type Props = {
+  entries: ProductListEntry[]
+  isAuthenticated: boolean
+  columnSettings: ProductTableColumnSettings
+  onColumnSettingsChange: (next: ProductTableColumnSettings) => void
+  onEdit: (productId: string) => void
+  onCopy: (productId: string) => void
+  onDelete: (product: Product) => void
+}
+
+const COLUMN_LABELS: Record<CustomizableProductColumnKey, string> = {
+  category: "カテゴリ",
+  options: "オプション/個数",
+  shipping: "配送方法",
+  equipment: "使用設備",
+  productionLotSize: "制作ロット数",
+  expectedProduction: "想定生産数",
+  salePrice: "販売価格",
+  profit: "利益",
+  notes: "備考",
+}
+
+const moveBefore = (
+  source: CustomizableProductColumnKey,
+  target: CustomizableProductColumnKey,
+  order: CustomizableProductColumnKey[]
+) => {
+  if (source === target) return order
+  const without = order.filter((key) => key !== source)
+  const index = without.indexOf(target)
+  if (index < 0) return order
+  return [...without.slice(0, index), source, ...without.slice(index)]
+}
+
+export function normalizeProductTableColumnSettings(raw: {
+  columnOrder?: string[] | null
+  hiddenColumns?: string[] | null
+}): ProductTableColumnSettings {
+  const validSet = new Set<string>(CUSTOMIZABLE_PRODUCT_COLUMNS)
+  const orderInput = Array.isArray(raw.columnOrder) ? raw.columnOrder : []
+  const hiddenInput = Array.isArray(raw.hiddenColumns) ? raw.hiddenColumns : []
+
+  const columnOrder = orderInput
+    .filter((key): key is CustomizableProductColumnKey => validSet.has(key))
+    .filter((key, index, arr) => arr.indexOf(key) === index)
+
+  CUSTOMIZABLE_PRODUCT_COLUMNS.forEach((key) => {
+    if (!columnOrder.includes(key)) {
+      columnOrder.push(key)
+    }
+  })
+
+  const hiddenColumns = hiddenInput
+    .filter((key): key is CustomizableProductColumnKey => validSet.has(key))
+    .filter((key, index, arr) => arr.indexOf(key) === index)
+
+  return { columnOrder, hiddenColumns }
+}
+
+export function defaultProductTableColumnSettings(): ProductTableColumnSettings {
+  return {
+    columnOrder: [...CUSTOMIZABLE_PRODUCT_COLUMNS],
+    hiddenColumns: [],
+  }
+}
+
+export function CustomizableProductTable({
+  entries,
+  isAuthenticated,
+  columnSettings,
+  onColumnSettingsChange,
+  onEdit,
+  onCopy,
+  onDelete,
+}: Props) {
+  const [draggingColumn, setDraggingColumn] = useState<CustomizableProductColumnKey | null>(null)
+  const [showHiddenColumns, setShowHiddenColumns] = useState(false)
+
+  const hiddenSet = useMemo(() => new Set(columnSettings.hiddenColumns), [columnSettings.hiddenColumns])
+  const visibleColumns = useMemo(
+    () => columnSettings.columnOrder.filter((key) => !hiddenSet.has(key)),
+    [columnSettings.columnOrder, hiddenSet]
+  )
+
+  const updateOrder = (nextOrder: CustomizableProductColumnKey[]) => {
+    onColumnSettingsChange({
+      ...columnSettings,
+      columnOrder: nextOrder,
+    })
+  }
+
+  const hideColumn = (key: CustomizableProductColumnKey) => {
+    if (columnSettings.hiddenColumns.includes(key)) return
+    onColumnSettingsChange({
+      ...columnSettings,
+      hiddenColumns: [...columnSettings.hiddenColumns, key],
+    })
+  }
+
+  const showColumn = (key: CustomizableProductColumnKey) => {
+    onColumnSettingsChange({
+      ...columnSettings,
+      hiddenColumns: columnSettings.hiddenColumns.filter((item) => item !== key),
+      columnOrder: columnSettings.columnOrder.includes(key)
+        ? columnSettings.columnOrder
+        : [...columnSettings.columnOrder, key],
+    })
+  }
+
+  const renderColumnCell = (key: CustomizableProductColumnKey, entry: ProductListEntry) => {
+    const { product, salePrice, profit, categoryPath, shippingText, equipmentText } = entry
+    switch (key) {
+      case "category":
+        return categoryPath
+      case "options": {
+        const optionText =
+          (product.sizeVariants ?? [])
+            .filter((variant) => variant.label?.trim())
+            .map((variant) => `${variant.label}: ${variant.quantity}個`)
+            .join(" / ") || "-"
+        return optionText
+      }
+      case "shipping":
+        return shippingText
+      case "equipment":
+        return equipmentText
+      case "productionLotSize":
+        return product.productionLotSize ?? 0
+      case "expectedProduction":
+        return product.expectedProduction?.quantity ?? 0
+      case "salePrice":
+        return formatCurrency(salePrice)
+      case "profit":
+        return formatCurrency(profit)
+      case "notes": {
+        const notesText = product.notes?.trim() || "-"
+        return notesText
+      }
+      default:
+        return "-"
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-2 rounded-md border border-dashed p-3 md:flex-row md:items-center md:justify-between">
+        <p className="text-xs text-muted-foreground">
+          {isAuthenticated
+            ? "「商品」列は固定です。その他の列はヘッダーをドラッグして並び替え、右側ドロップで非表示にできます。"
+            : "カラムカスタマイズはログイン中のみ利用できます。"}
+        </p>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => setShowHiddenColumns((prev) => !prev)}
+            disabled={!isAuthenticated}
+          >
+            非表示列 ({columnSettings.hiddenColumns.length})
+          </Button>
+          <div
+            className="rounded-md border border-dashed px-3 py-1.5 text-xs text-muted-foreground"
+            onDragOver={(event) => {
+              if (!isAuthenticated || !draggingColumn) return
+              event.preventDefault()
+            }}
+            onDrop={(event) => {
+              if (!isAuthenticated || !draggingColumn) return
+              event.preventDefault()
+              hideColumn(draggingColumn)
+              setDraggingColumn(null)
+            }}
+          >
+            非表示エリアへドロップ
+          </div>
+        </div>
+      </div>
+
+      {showHiddenColumns && (
+        <div className="rounded-md border p-3">
+          {columnSettings.hiddenColumns.length === 0 ? (
+            <p className="text-xs text-muted-foreground">非表示の列はありません。</p>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {columnSettings.hiddenColumns.map((key) => (
+                <Button
+                  key={key}
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => showColumn(key)}
+                  disabled={!isAuthenticated}
+                >
+                  {COLUMN_LABELS[key]} を表示
+                </Button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>商品</TableHead>
+              {visibleColumns.map((key) => (
+                <TableHead
+                  key={key}
+                  onDragOver={(event) => {
+                    if (!isAuthenticated || !draggingColumn) return
+                    event.preventDefault()
+                  }}
+                  onDrop={(event) => {
+                    if (!isAuthenticated || !draggingColumn) return
+                    event.preventDefault()
+                    updateOrder(moveBefore(draggingColumn, key, columnSettings.columnOrder))
+                    setDraggingColumn(null)
+                  }}
+                >
+                  <div
+                    className={`inline-flex items-center gap-1 rounded px-1 py-0.5 ${
+                      isAuthenticated ? "cursor-move hover:bg-muted" : ""
+                    }`}
+                    draggable={isAuthenticated}
+                    onDragStart={() => setDraggingColumn(key)}
+                    onDragEnd={() => setDraggingColumn(null)}
+                    title={isAuthenticated ? "ドラッグして並び替え/非表示" : undefined}
+                  >
+                    {isAuthenticated && <GripVertical className="h-3.5 w-3.5 text-muted-foreground" />}
+                    {COLUMN_LABELS[key]}
+                  </div>
+                </TableHead>
+              ))}
+              <TableHead />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {entries.map((entry) => (
+              <TableRow key={entry.product.id}>
+                <TableCell className="font-medium">{entry.product.name}</TableCell>
+                {visibleColumns.map((key) => (
+                  <TableCell
+                    key={`${entry.product.id}-${key}`}
+                    className={
+                      key === "profit"
+                        ? entry.profit >= 0
+                          ? "text-green-600"
+                          : "text-red-600"
+                        : key === "options" || key === "shipping" || key === "equipment" || key === "notes" || key === "productionLotSize" || key === "expectedProduction"
+                          ? "text-xs text-muted-foreground"
+                          : undefined
+                    }
+                  >
+                    {renderColumnCell(key, entry)}
+                  </TableCell>
+                ))}
+                <TableCell className="w-48 text-right">
+                  <div className="flex flex-wrap justify-end gap-2">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      className="w-full sm:w-auto"
+                      onClick={() => onEdit(entry.product.id)}
+                    >
+                      <Edit3 className="mr-1 h-4 w-4" />
+                      編集
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="secondary"
+                      className="w-full sm:w-auto"
+                      onClick={() => onCopy(entry.product.id)}
+                    >
+                      <Copy className="mr-1 h-4 w-4" />
+                      コピー
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="destructive"
+                      className="w-full sm:w-auto"
+                      onClick={() => onDelete(entry.product)}
+                    >
+                      <Trash2 className="mr-1 h-4 w-4" />
+                      削除
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useMemo, useRef, useState, type ChangeEvent } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -15,9 +15,9 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useAppData } from "@/lib/app-data"
+import { loadProductListColumnSettings, upsertProductListColumnSettings } from "@/lib/app-data-sync"
 import { calculateProductUnitCosts, formatCurrency } from "@/lib/calculations"
 import type { AppData, AuditFilters, Product } from "@/lib/types"
 import { AnalyticsTab } from "./_components/analytics/analytics-tab"
@@ -25,10 +25,16 @@ import { AuditTab } from "./_components/audit/audit-tab"
 import { BulkTab } from "./_components/bulk/bulk-tab"
 import { CostTab } from "./_components/cost/cost-tab"
 import { MasterTab } from "./_components/master/master-tab"
+import {
+  CustomizableProductTable,
+  defaultProductTableColumnSettings,
+  normalizeProductTableColumnSettings,
+  type ProductTableColumnSettings,
+} from "./_components/product-list/customizable-product-table"
 import { ProductTab } from "./_components/product/product-tab"
 import { RegisteredProductsSection } from "./_components/product/sections/registered-products-section"
 import { StockTab } from "./_components/stock/stock-tab"
-import { Copy, Edit3, FileDown, FileUp, Menu, Plus, Trash2 } from "lucide-react"
+import { FileDown, FileUp, Menu, Plus } from "lucide-react"
 import { toast } from "sonner"
 import { useAuth } from "@/lib/auth"
 
@@ -100,8 +106,12 @@ export default function Home() {
   const [isSendingReset, setIsSendingReset] = useState(false)
   const [pendingDeleteProduct, setPendingDeleteProduct] = useState<Product | null>(null)
   const [pendingBackupRestore, setPendingBackupRestore] = useState<{ fileName: string; data: Partial<AppData> } | null>(null)
+  const [productTableColumnSettings, setProductTableColumnSettings] = useState<ProductTableColumnSettings>(
+    () => defaultProductTableColumnSettings()
+  )
   const backupImportInputRef = useRef<HTMLInputElement | null>(null)
   const importGuestData = actions.importGuestData
+  const authUserId = authState.status === "authenticated" ? authState.user.id : null
   const productCostMap = useMemo(() => {
     const map = new Map<string, ReturnType<typeof calculateProductUnitCosts>>()
     data.products.forEach((product) => {
@@ -569,6 +579,49 @@ export default function Home() {
     setProductCategorySmallFilter(value === "all" ? null : value)
   }, [])
 
+  const handleProductTableColumnSettingsChange = useCallback(
+    (next: ProductTableColumnSettings) => {
+      const normalized = normalizeProductTableColumnSettings(next)
+      setProductTableColumnSettings(normalized)
+      if (!authUserId) return
+      void upsertProductListColumnSettings(authUserId, normalized.columnOrder, normalized.hiddenColumns).catch((error) => {
+        console.error("Failed to save product list column settings", error)
+        toast.error("カラム設定の保存に失敗しました")
+      })
+    },
+    [authUserId]
+  )
+
+  useEffect(() => {
+    let cancelled = false
+    if (!authUserId) {
+      setProductTableColumnSettings(defaultProductTableColumnSettings())
+      return () => {
+        cancelled = true
+      }
+    }
+    ;(async () => {
+      try {
+        const loaded = await loadProductListColumnSettings(authUserId)
+        if (cancelled) return
+        if (!loaded) {
+          setProductTableColumnSettings(defaultProductTableColumnSettings())
+          return
+        }
+        setProductTableColumnSettings(normalizeProductTableColumnSettings(loaded))
+      } catch (error) {
+        console.error("Failed to load product list column settings", error)
+        if (!cancelled) {
+          setProductTableColumnSettings(defaultProductTableColumnSettings())
+          toast.error("カラム設定の読み込みに失敗しました")
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [authUserId])
+
   const renderLoading = () => (
     <main className="mx-auto flex min-h-screen max-w-4xl flex-col items-center justify-center gap-4 p-10 text-muted-foreground">
       <div className="h-10 w-10 animate-spin rounded-full border-4 border-muted border-t-transparent" />
@@ -937,85 +990,15 @@ export default function Home() {
               ) : filteredProductEntries.length === 0 ? (
                 <p className="text-sm text-muted-foreground">条件に一致する商品がありません。</p>
               ) : (
-                <div className="overflow-x-auto">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>商品</TableHead>
-                      <TableHead>カテゴリ</TableHead>
-                    <TableHead>オプション/個数</TableHead>
-                    <TableHead>配送方法</TableHead>
-                    <TableHead>使用設備</TableHead>
-                    <TableHead>制作ロット数</TableHead>
-                    <TableHead>想定生産数</TableHead>
-                    <TableHead>販売価格</TableHead>
-                    <TableHead>利益</TableHead>
-                    <TableHead>備考</TableHead>
-                    <TableHead />
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {filteredProductEntries.map(({ product, salePrice, profit, categoryPath, shippingText, equipmentText }) => {
-                      const optionText = (product.sizeVariants ?? [])
-                        .filter((variant) => variant.label?.trim())
-                        .map((variant) => `${variant.label}: ${variant.quantity}個`)
-                        .join(" / ") || "-"
-                      const notesText = product.notes?.trim() || "-"
-
-                      return (
-                        <TableRow key={product.id}>
-                          <TableCell className="font-medium">{product.name}</TableCell>
-                          <TableCell>{categoryPath}</TableCell>
-                          <TableCell className="text-xs text-muted-foreground">{optionText}</TableCell>
-                          <TableCell className="text-xs text-muted-foreground">{shippingText}</TableCell>
-                          <TableCell className="text-xs text-muted-foreground">{equipmentText}</TableCell>
-                          <TableCell className="text-xs text-muted-foreground">{product.productionLotSize ?? 0}</TableCell>
-                          <TableCell className="text-xs text-muted-foreground">{product.expectedProduction?.quantity ?? 0}</TableCell>
-                          <TableCell>{formatCurrency(salePrice)}</TableCell>
-                          <TableCell className={profit >= 0 ? "text-green-600" : "text-red-600"}>
-                            {formatCurrency(profit)}
-                          </TableCell>
-                          <TableCell className="text-xs text-muted-foreground">{notesText}</TableCell>
-                          <TableCell className="w-48 text-right">
-                            <div className="flex flex-wrap justify-end gap-2">
-                              <Button
-                                type="button"
-                                size="sm"
-                                variant="outline"
-                                className="w-full sm:w-auto"
-                                onClick={() => handleEditProduct(product.id)}
-                              >
-                                <Edit3 className="mr-1 h-4 w-4" />
-                                編集
-                              </Button>
-                              <Button
-                                type="button"
-                                size="sm"
-                                variant="secondary"
-                                className="w-full sm:w-auto"
-                                onClick={() => handleCopyProduct(product.id)}
-                              >
-                                <Copy className="mr-1 h-4 w-4" />
-                                コピー
-                              </Button>
-                              <Button
-                                type="button"
-                                size="sm"
-                                variant="destructive"
-                                className="w-full sm:w-auto"
-                                onClick={() => handleDeleteProduct(product)}
-                              >
-                                <Trash2 className="mr-1 h-4 w-4" />
-                                削除
-                              </Button>
-                            </div>
-                          </TableCell>
-                        </TableRow>
-                      )
-                    })}
-                  </TableBody>
-                  </Table>
-                </div>
+                <CustomizableProductTable
+                  entries={filteredProductEntries}
+                  isAuthenticated={isAuthenticated}
+                  columnSettings={productTableColumnSettings}
+                  onColumnSettingsChange={handleProductTableColumnSettingsChange}
+                  onEdit={handleEditProduct}
+                  onCopy={handleCopyProduct}
+                  onDelete={handleDeleteProduct}
+                />
               )}
             </CardContent>
           </Card>

--- a/src/lib/app-data-sync.ts
+++ b/src/lib/app-data-sync.ts
@@ -984,6 +984,45 @@ export async function deletePackagingStock(userId: string, packagingItemId: stri
   if (error) throw error
 }
 
+type ProductListColumnSettingsRow = {
+  column_order: string[] | null
+  hidden_columns: string[] | null
+}
+
+export async function loadProductListColumnSettings(
+  userId: string
+): Promise<{ columnOrder: string[]; hiddenColumns: string[] } | null> {
+  const { data, error } = await supabaseClient
+    .from("product_list_column_settings")
+    .select("column_order, hidden_columns")
+    .eq("user_id", userId)
+    .maybeSingle()
+  if (error) throw error
+  if (!data) return null
+  const row = data as ProductListColumnSettingsRow
+  return {
+    columnOrder: Array.isArray(row.column_order) ? row.column_order : [],
+    hiddenColumns: Array.isArray(row.hidden_columns) ? row.hidden_columns : [],
+  }
+}
+
+export async function upsertProductListColumnSettings(
+  userId: string,
+  columnOrder: string[],
+  hiddenColumns: string[]
+): Promise<void> {
+  const { error } = await supabaseClient.from("product_list_column_settings").upsert(
+    {
+      user_id: userId,
+      column_order: columnOrder,
+      hidden_columns: hiddenColumns,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "user_id" }
+  )
+  if (error) throw error
+}
+
 export async function loadAuditLogs(
   userId: string,
   limit = 50,

--- a/supabase/migrations/20260306_product_list_column_settings.sql
+++ b/supabase/migrations/20260306_product_list_column_settings.sql
@@ -1,0 +1,13 @@
+create table if not exists product_list_column_settings (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  column_order text[] not null default '{}'::text[],
+  hidden_columns text[] not null default '{}'::text[],
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+alter table product_list_column_settings enable row level security;
+
+create policy "product_list_column_settings_own" on product_list_column_settings
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
## 概要
- 商品一覧テーブルを `CustomizableProductTable` コンポーネントへ切り出し
- 商品列を固定したまま、他列のドラッグ&ドロップ並び替えを追加
- 右側の「非表示エリア」へのドロップで列を非表示化
- 「非表示列」ボタンから非表示列を再表示できる UI を追加
- `product_list_column_settings` テーブルを追加し、ログインユーザーの設定を Supabase に保存・再読込
- 未ログイン時はデフォルト列順/表示のみ利用可能に制限

## 変更ファイル
- `supabase/migrations/20260306_product_list_column_settings.sql`
- `src/lib/app-data-sync.ts`
- `src/app/_components/product-list/customizable-product-table.tsx`
- `src/app/page.tsx`

## 受け入れ条件
- [x] ログインユーザーのみカスタマイズ機能が利用可能
- [x] 商品列は固定で移動できない
- [x] 他の列はドラッグ&ドロップで順序変更できる
- [x] 列を非表示エリアにドロップすると非表示になる
- [x] 非表示の列を一覧表示し、クリックで表示に戻せる
- [x] 設定がリロード後も保持される（Supabase保存）
- [x] 未ログイン時はデフォルト表示

## 動作確認
- `npm run lint` を実行
- ローカル環境では `eslint: command not found`（依存未導入）で実行不可

Closes #123
