### PR TITLE
Issue #127 商品登録タブ復活と商品一覧在庫列の追加

### DIFF
--- a/src/app/_components/product-list/customizable-product-table.tsx
+++ b/src/app/_components/product-list/customizable-product-table.tsx
@@ -3,12 +3,15 @@
 import { useMemo, useState } from "react"
 import { Copy, Edit3, GripVertical, Trash2 } from "lucide-react"
 
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { formatCurrency } from "@/lib/calculations"
 import type { Product } from "@/lib/types"
+import { toast } from "sonner"
 
 export const CUSTOMIZABLE_PRODUCT_COLUMNS = [
+  "stock",
   "category",
   "options",
   "shipping",
@@ -39,14 +42,18 @@ export type ProductTableColumnSettings = {
 type Props = {
   entries: ProductListEntry[]
   isAuthenticated: boolean
+  stocks: Map<string, number>
+  stocksLoaded: boolean
   columnSettings: ProductTableColumnSettings
   onColumnSettingsChange: (next: ProductTableColumnSettings) => void
+  onAdjustStock: (productId: string, delta: number) => Promise<void>
   onEdit: (productId: string) => void
   onCopy: (productId: string) => void
   onDelete: (product: Product) => void
 }
 
 const COLUMN_LABELS: Record<CustomizableProductColumnKey, string> = {
+  stock: "在庫",
   category: "カテゴリ",
   options: "オプション/個数",
   shipping: "配送方法",
@@ -105,14 +112,18 @@ export function defaultProductTableColumnSettings(): ProductTableColumnSettings 
 export function CustomizableProductTable({
   entries,
   isAuthenticated,
+  stocks,
+  stocksLoaded,
   columnSettings,
   onColumnSettingsChange,
+  onAdjustStock,
   onEdit,
   onCopy,
   onDelete,
 }: Props) {
   const [draggingColumn, setDraggingColumn] = useState<CustomizableProductColumnKey | null>(null)
   const [showHiddenColumns, setShowHiddenColumns] = useState(false)
+  const [busyKey, setBusyKey] = useState<string | null>(null)
 
   const hiddenSet = useMemo(() => new Set(columnSettings.hiddenColumns), [columnSettings.hiddenColumns])
   const visibleColumns = useMemo(
@@ -145,9 +156,60 @@ export function CustomizableProductTable({
     })
   }
 
+  const adjustStock = async (productId: string, delta: number) => {
+    setBusyKey(`${productId}:${delta > 0 ? "add" : "use"}`)
+    try {
+      await onAdjustStock(productId, delta)
+    } catch {
+      toast.error("在庫の更新に失敗しました")
+    } finally {
+      setBusyKey(null)
+    }
+  }
+
   const renderColumnCell = (key: CustomizableProductColumnKey, entry: ProductListEntry) => {
     const { product, salePrice, profit, categoryPath, shippingText, equipmentText } = entry
+    const stockQuantity = stocks.get(product.id) ?? 0
+    const isBusy = busyKey?.startsWith(`${product.id}:`) ?? false
     switch (key) {
+      case "stock":
+        return (
+          <div className="flex items-center gap-2">
+            {isAuthenticated ? (
+              stocksLoaded ? (
+                <Badge variant={stockQuantity === 0 ? "outline" : "secondary"} className="min-w-10 justify-center text-sm">
+                  {stockQuantity}
+                </Badge>
+              ) : (
+                <span className="text-xs text-muted-foreground">読込中...</span>
+              )
+            ) : (
+              <span className="text-xs text-muted-foreground">-</span>
+            )}
+            <div className="flex gap-1">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-7 w-7 px-0"
+                onClick={() => adjustStock(product.id, 1)}
+                disabled={!isAuthenticated || !stocksLoaded || isBusy}
+              >
+                +
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-7 w-7 px-0"
+                onClick={() => adjustStock(product.id, -1)}
+                disabled={!isAuthenticated || !stocksLoaded || isBusy || stockQuantity === 0}
+              >
+                -
+              </Button>
+            </div>
+          </div>
+        )
       case "category":
         return categoryPath
       case "options": {

--- a/src/app/_components/product/product-tab.tsx
+++ b/src/app/_components/product/product-tab.tsx
@@ -4,6 +4,7 @@ import type { AppActions } from "@/lib/app-data"
 import type { AppData } from "@/lib/types"
 
 import { ProductFormPanel } from "./product-form-panel"
+import { RegisteredProductsSection } from "./sections/registered-products-section"
 
 interface ProductTabProps {
   data: AppData
@@ -16,9 +17,12 @@ interface ProductTabProps {
 }
 
 export function ProductTab(props: ProductTabProps) {
+  const { data } = props
+
   return (
     <div className="space-y-6">
       <ProductFormPanel {...props} />
+      <RegisteredProductsSection data={data} readOnly />
     </div>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,7 +32,6 @@ import {
   type ProductTableColumnSettings,
 } from "./_components/product-list/customizable-product-table"
 import { ProductTab } from "./_components/product/product-tab"
-import { RegisteredProductsSection } from "./_components/product/sections/registered-products-section"
 import { StockTab } from "./_components/stock/stock-tab"
 import { FileDown, FileUp, Menu, Plus } from "lucide-react"
 import { toast } from "sonner"
@@ -878,15 +877,6 @@ export default function Home() {
         </TabsContent>
 
         <TabsContent value="list" className="space-y-6">
-          <RegisteredProductsSection
-            data={data}
-            stocks={stocks}
-            stocksLoaded={stocksLoaded}
-            isAuthenticated={isAuthenticated}
-            onAdjust={adjustStock}
-            onSet={setStock}
-          />
-
           <Card>
             <CardHeader className="space-y-4">
               <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
@@ -993,8 +983,11 @@ export default function Home() {
                 <CustomizableProductTable
                   entries={filteredProductEntries}
                   isAuthenticated={isAuthenticated}
+                  stocks={stocks}
+                  stocksLoaded={stocksLoaded}
                   columnSettings={productTableColumnSettings}
                   onColumnSettingsChange={handleProductTableColumnSettingsChange}
+                  onAdjustStock={adjustStock}
                   onEdit={handleEditProduct}
                   onCopy={handleCopyProduct}
                   onDelete={handleDeleteProduct}


### PR DESCRIPTION
## 概要
- 商品一覧タブから `RegisteredProductsSection` を削除（重複表示の解消）
- 商品登録タブに `RegisteredProductsSection` を復活
- 商品一覧テーブル（カラムカスタマイズ対応）に「在庫」列を追加
- 商品一覧テーブルの在庫列で `+ / -` による在庫増減を追加
- 在庫タブの `+ / -` 表記が維持されていることを確認

## 変更ファイル
- `src/app/page.tsx`
- `src/app/_components/product/product-tab.tsx`
- `src/app/_components/product-list/customizable-product-table.tsx`

## 受け入れ条件
- [x] 商品一覧タブに「登録済み商品」セクションがない
- [x] 商品登録タブに「登録済み商品」セクションが表示される
- [x] 商品一覧タブに「在庫」列が表示される
- [x] 商品一覧タブで在庫の増減（+/-ボタン）ができる
- [x] 在庫タブのボタンが「+」「-」になっている
- [x] 商品一覧タブの在庫列がカラムカスタマイズ機能で並び替え・非表示可能

## 動作確認
- `npm run lint` を実行
- ローカル環境では `eslint: command not found`（依存未導入）で実行不可

Closes #127
