### PR TITLE
Issue #124 材料使用量モード変更と在庫自動消費

### DIFF
--- a/src/app/_components/cost/sections/material-usage-section.tsx
+++ b/src/app/_components/cost/sections/material-usage-section.tsx
@@ -21,7 +21,8 @@ export function MaterialUsageSection({ data }: MaterialUsageSectionProps) {
         unit?: string
         currency?: string
         baseUnitCost?: number
-        totalUsageRatio?: number
+        totalUsageInput?: number
+        usePercentageMode?: boolean
         supplier?: string
         entries: {
           productName: string
@@ -40,7 +41,8 @@ export function MaterialUsageSection({ data }: MaterialUsageSectionProps) {
           unit: material.unit,
           currency: material.currency,
           baseUnitCost: material.unitCost,
-          totalUsageRatio: undefined,
+          totalUsageInput: undefined,
+          usePercentageMode: material.usePercentageMode,
           supplier: material.supplier,
           entries: [],
         })
@@ -57,7 +59,7 @@ export function MaterialUsageSection({ data }: MaterialUsageSectionProps) {
       const group = ensureGroup(material)
       group.currency = entry.currency ?? group.currency
       if (entry.usageRatio !== undefined) {
-        group.totalUsageRatio = (group.totalUsageRatio ?? 0) + entry.usageRatio
+        group.totalUsageInput = (group.totalUsageInput ?? 0) + entry.usageRatio
       }
       group.entries.push({
         productName,
@@ -86,7 +88,7 @@ export function MaterialUsageSection({ data }: MaterialUsageSectionProps) {
                 <TableRow>
                   <TableHead>材料</TableHead>
                   <TableHead>仕入先</TableHead>
-                  <TableHead>総使用率</TableHead>
+                  <TableHead>総使用量</TableHead>
                   <TableHead>単価</TableHead>
                   <TableHead>内訳</TableHead>
                 </TableRow>
@@ -96,7 +98,13 @@ export function MaterialUsageSection({ data }: MaterialUsageSectionProps) {
                   <TableRow key={`summary-${group.materialId}`}>
                     <TableCell>{group.materialName}</TableCell>
                     <TableCell>{group.supplier ?? "-"}</TableCell>
-                    <TableCell>{group.totalUsageRatio !== undefined ? `${group.totalUsageRatio}%` : "-"}</TableCell>
+                    <TableCell>
+                      {group.totalUsageInput !== undefined
+                        ? group.usePercentageMode
+                          ? `${group.totalUsageInput}%`
+                          : `${group.totalUsageInput}${group.unit ?? ""}`
+                        : "-"}
+                    </TableCell>
                     <TableCell>
                       {group.baseUnitCost !== undefined
                         ? formatCurrency(group.baseUnitCost, group.currency ?? "JPY")
@@ -107,7 +115,12 @@ export function MaterialUsageSection({ data }: MaterialUsageSectionProps) {
                         ? "-"
                         : group.entries
                             .map((entry) => {
-                              const ratioText = entry.usageRatio !== undefined ? `${entry.usageRatio}%` : "-"
+                              const ratioText =
+                                entry.usageRatio !== undefined
+                                  ? group.usePercentageMode
+                                    ? `${entry.usageRatio}%`
+                                    : `${entry.usageRatio}${group.unit ?? ""}`
+                                  : "-"
                               const costText =
                                 entry.costShare !== undefined
                                   ? formatCurrency(entry.costShare, group.currency ?? "JPY")

--- a/src/app/_components/master/sections/material/material-list-section.tsx
+++ b/src/app/_components/master/sections/material/material-list-section.tsx
@@ -36,6 +36,7 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
     currency: "JPY",
     unitCost: 0,
     unitsPerBatch: 1,
+    usePercentageMode: false,
     supplier: "",
     note: "",
   })
@@ -97,6 +98,7 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
       currency: "JPY",
       unitCost: 0,
       unitsPerBatch: 1,
+      usePercentageMode: false,
       supplier: "",
       note: "",
     })
@@ -149,6 +151,7 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
       currency: material.currency,
       unitCost: material.unitCost,
       unitsPerBatch: material.unitsPerBatch ?? 1,
+      usePercentageMode: material.usePercentageMode ?? false,
       supplier: material.supplier,
       note: material.note,
     })
@@ -161,6 +164,7 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
       currency: material.currency,
       unitCost: material.unitCost,
       unitsPerBatch: material.unitsPerBatch ?? 1,
+      usePercentageMode: material.usePercentageMode ?? false,
       supplier: material.supplier ?? "",
       note: material.note ?? "",
     })
@@ -183,6 +187,7 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
                   <TableHead>単位</TableHead>
                   <TableHead>単価</TableHead>
                   <TableHead>セット数</TableHead>
+                  <TableHead>入力モード</TableHead>
                   <TableHead>仕入先</TableHead>
                   <TableHead>備考</TableHead>
                   <TableHead>現在残数</TableHead>
@@ -261,6 +266,24 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
                           `${material.unitsPerBatch}単位/セット`
                         ) : (
                           "1単位/セット"
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        {isEditing ? (
+                          <label className="inline-flex items-center gap-2 text-xs">
+                            <input
+                              type="checkbox"
+                              checked={Boolean(editingMaterial.usePercentageMode)}
+                              onChange={(event) =>
+                                setEditingMaterial((prev) => ({ ...prev, usePercentageMode: event.target.checked }))
+                              }
+                            />
+                            %入力
+                          </label>
+                        ) : material.usePercentageMode ? (
+                          "%入力"
+                        ) : (
+                          "単位数"
                         )}
                       </TableCell>
                       <TableCell>

--- a/src/app/_components/master/sections/material/material-section.tsx
+++ b/src/app/_components/master/sections/material/material-section.tsx
@@ -31,6 +31,7 @@ const INITIAL_FORM: Omit<Material, "id"> = {
   currency: "JPY",
   unitCost: 0,
   unitsPerBatch: 1,
+  usePercentageMode: false,
   supplier: "",
   note: "",
 }
@@ -127,6 +128,20 @@ export function MaterialSection({ data, actions, isAuthenticated, onSetMaterialS
               }}
             />
             <FieldHint>仕入れ単位が1ロール=50mなどの場合の個数。1個売りなら1。</FieldHint>
+          </div>
+          <div className="space-y-1">
+            <Label className="text-xs text-muted-foreground">材料使用量の入力モード</Label>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={Boolean(materialForm.usePercentageMode)}
+                onChange={(event) =>
+                  setMaterialForm((prev) => ({ ...prev, usePercentageMode: event.target.checked }))
+                }
+              />
+              パーセント指定モード（ONで商品登録時に%入力）
+            </label>
+            <FieldHint>OFFの場合は「使用量=単位数」で入力、ONの場合は「使用量=%」で入力します。</FieldHint>
           </div>
           {isAuthenticated ? (
             <div className="space-y-1">

--- a/src/app/_components/product/hooks/use-product-drafts.ts
+++ b/src/app/_components/product/hooks/use-product-drafts.ts
@@ -110,7 +110,7 @@ export function useProductDraftState({
   const createMaterialDraft = useCallback((): MaterialCostDraft => ({
     id: createTempId(),
     materialId: data.materials[0]?.id ?? "",
-    usageRatio: 100,
+    usageRatio: 1,
     description: "",
   }), [data.materials])
 

--- a/src/app/_components/product/hooks/use-product-form.ts
+++ b/src/app/_components/product/hooks/use-product-form.ts
@@ -65,10 +65,11 @@ export function useProductFormState(args: UseProductFormStateArgs): ProductFormS
     const material = materialDrafts.reduce((sum, draft) => {
       const material = data.materials.find((item) => item.id === draft.materialId)
       if (!material) return sum
-      const usageRatio = Math.max(Number(draft.usageRatio) || 0, 0)
+      const usageInput = Math.max(Number(draft.usageRatio) || 0, 0)
+      const consumptionPerProduct = material.usePercentageMode ? usageInput / 100 : usageInput
       const batchSize = Math.max(material.unitsPerBatch ?? 1, 1)
       const baseUnitCost = (material.unitCost || 0) / batchSize
-      return sum + baseUnitCost * (usageRatio / 100)
+      return sum + baseUnitCost * consumptionPerProduct
     }, 0)
 
     const packaging = packagingDrafts.reduce((sum, draft) => {
@@ -241,15 +242,6 @@ export function useProductFormState(args: UseProductFormStateArgs): ProductFormS
         removeCostEntriesByProduct(args.editingProductId)
       } else {
         addProduct({ id: targetProductId, ...normalizedProduct })
-        if (args.onSetStock) {
-          try {
-            const normalizedInitialStock = Math.max(0, Number(initialStock) || 0)
-            await args.onSetStock(targetProductId, normalizedInitialStock)
-          } catch (error) {
-            console.error("Failed to save initial product stock", error)
-            toast.error("初期在庫数の保存に失敗しました")
-          }
-        }
       }
 
       // cost entries
@@ -259,9 +251,10 @@ export function useProductFormState(args: UseProductFormStateArgs): ProductFormS
           const material = data.materials.find((item) => item.id === draft.materialId)
           if (!material) return
           const usageRatio = Math.max(Number(draft.usageRatio) || 0, 0)
+          const consumptionPerProduct = material.usePercentageMode ? usageRatio / 100 : usageRatio
           const batchSize = Math.max(material.unitsPerBatch ?? 1, 1)
           const baseUnitCost = (material.unitCost || 0) / batchSize
-          const costPerUnit = baseUnitCost * (usageRatio / 100)
+          const costPerUnit = baseUnitCost * consumptionPerProduct
           addMaterialCostEntry({
             productId: targetProductId,
             materialId: draft.materialId,
@@ -377,6 +370,16 @@ export function useProductFormState(args: UseProductFormStateArgs): ProductFormS
             currency: fee.currency,
           })
         })
+
+      if (!isEditing && args.onSetStock) {
+        try {
+          const normalizedInitialStock = Math.max(0, Number(initialStock) || 0)
+          await args.onSetStock(targetProductId, normalizedInitialStock)
+        } catch (error) {
+          console.error("Failed to save initial product stock", error)
+          toast.error("初期在庫数の保存に失敗しました")
+        }
+      }
 
       toast.success(isEditing ? "商品を更新しました" : "商品を登録しました", {
         description: `「${normalizedProduct.name || "商品"}」の原価情報を保存しました。`,

--- a/src/app/_components/product/product-form-panel.tsx
+++ b/src/app/_components/product/product-form-panel.tsx
@@ -21,6 +21,9 @@ import { FeeCostSection } from "./sections/fee-cost-section"
 interface ProductFormPanelProps {
   data: AppData
   actions: AppActions
+  materialStocks: Map<string, number>
+  masterStocksLoaded: boolean
+  isAuthenticated: boolean
   onSetStock?: (productId: string, quantity: number) => Promise<void>
   editingProductId?: string | null
   onRequestEditClear?: () => void
@@ -31,6 +34,9 @@ interface ProductFormPanelProps {
 export function ProductFormPanel(props: ProductFormPanelProps) {
   const {
     data,
+    materialStocks,
+    masterStocksLoaded,
+    isAuthenticated,
     editingProductId,
   } = props
 
@@ -122,6 +128,9 @@ export function ProductFormPanel(props: ProductFormPanelProps) {
 
                 <MaterialCostSection
                   materials={data.materials}
+                  materialStocks={materialStocks}
+                  masterStocksLoaded={masterStocksLoaded}
+                  isAuthenticated={isAuthenticated}
                   drafts={materialDrafts}
                   onAdd={handleAddMaterialDraft}
                   onUpdate={handleUpdateMaterialDraft}

--- a/src/app/_components/product/product-tab.tsx
+++ b/src/app/_components/product/product-tab.tsx
@@ -9,6 +9,9 @@ import { RegisteredProductsSection } from "./sections/registered-products-sectio
 interface ProductTabProps {
   data: AppData
   actions: AppActions
+  materialStocks: Map<string, number>
+  masterStocksLoaded: boolean
+  isAuthenticated: boolean
   onSetStock?: (productId: string, quantity: number) => Promise<void>
   editingProductId?: string | null
   onRequestEditClear?: () => void

--- a/src/app/_components/product/sections/material-cost-section.tsx
+++ b/src/app/_components/product/sections/material-cost-section.tsx
@@ -13,17 +13,29 @@ import type { MaterialCostDraft } from "../types"
 
 interface MaterialCostSectionProps {
   materials: Material[]
+  materialStocks: Map<string, number>
+  masterStocksLoaded: boolean
+  isAuthenticated: boolean
   drafts: MaterialCostDraft[]
   onAdd: () => void
   onUpdate: (id: string, patch: Partial<MaterialCostDraft>) => void
   onRemove: (id: string) => void
 }
 
-export function MaterialCostSection({ materials, drafts, onAdd, onUpdate, onRemove }: MaterialCostSectionProps) {
+export function MaterialCostSection({
+  materials,
+  materialStocks,
+  masterStocksLoaded,
+  isAuthenticated,
+  drafts,
+  onAdd,
+  onUpdate,
+  onRemove,
+}: MaterialCostSectionProps) {
   return (
     <FormSection
       title="材料費"
-      description="材料マスタから選択し、使用率だけ入力すれば単価を自動参照"
+      description="材料マスタから選択し、使用量（単位数 or %）を入力して単価を自動参照"
       defaultOpen
       action={
         <Button type="button" variant="outline" size="sm" onClick={onAdd} disabled={materials.length === 0}>
@@ -34,7 +46,7 @@ export function MaterialCostSection({ materials, drafts, onAdd, onUpdate, onRemo
       <HintList
         items={[
           "材料マスタ: 事前登録した素材を選択（単価・通貨はマスタ値を使用）",
-          "使用率(%): 仕入れたロットのうち1個あたりで使う割合",
+          "使用量: 材料マスタのモードに応じて単位数または%で入力",
           "用途: 本体用・持ち手用などのメモ",
         ]}
       />
@@ -48,6 +60,16 @@ export function MaterialCostSection({ materials, drafts, onAdd, onUpdate, onRemo
           const unitCostLabel = selectedMaterial
             ? `${formatCurrency(selectedMaterial.unitCost, selectedMaterial.currency)} / ${selectedMaterial.unit ?? "任意単位"}`
             : "材料マスタで単価を登録すると自動計算されます。"
+          const usePercentageMode = Boolean(selectedMaterial?.usePercentageMode)
+          const stockQuantity = selectedMaterial ? materialStocks.get(selectedMaterial.id) : undefined
+          const stockText =
+            !isAuthenticated
+              ? "在庫表示はログイン中のみ利用できます。"
+              : !masterStocksLoaded
+                ? "在庫: 読み込み中..."
+                : stockQuantity === undefined
+                  ? "在庫: 未設定"
+                  : `在庫: ${stockQuantity} ${selectedMaterial?.unit ?? ""}`.trim()
           return (
             <DraftCard key={draft.id} onRemove={() => onRemove(draft.id)}>
               <div className="space-y-3">
@@ -78,9 +100,11 @@ export function MaterialCostSection({ materials, drafts, onAdd, onUpdate, onRemo
                 </div>
                 <div className="grid gap-2 md:grid-cols-2">
                   <div className="space-y-1">
-                    <Label className="text-xs text-muted-foreground">使用率 (%)</Label>
+                    <Label className="text-xs text-muted-foreground">
+                      {usePercentageMode ? "使用量 (%)" : `使用量 (${selectedMaterial?.unit ?? "単位"})`}
+                    </Label>
                     <NumberInput
-                      placeholder="例: 75"
+                      placeholder={usePercentageMode ? "例: 5" : "例: 2"}
                       value={draft.usageRatio}
                       onValueChange={(next) =>
                         onUpdate(draft.id, {
@@ -88,7 +112,11 @@ export function MaterialCostSection({ materials, drafts, onAdd, onUpdate, onRemo
                         })
                       }
                     />
-                    <FieldHint>仕入れたロットのうち1商品あたりで使う割合。例: 1ロールの25%なら25。</FieldHint>
+                    <FieldHint>
+                      {usePercentageMode
+                        ? "100%で1単位消費します。例: 5%入力で0.05単位を消費。"
+                        : "1商品あたりの使用単位数を入力します。例: 2で2単位消費。"}
+                    </FieldHint>
                   </div>
                   <div className="space-y-1">
                     <Label className="text-xs text-muted-foreground">用途メモ</Label>
@@ -104,6 +132,7 @@ export function MaterialCostSection({ materials, drafts, onAdd, onUpdate, onRemo
                   </div>
                 </div>
                 <p className="text-xs text-muted-foreground">材料単価: {unitCostLabel}</p>
+                <p className="text-xs text-muted-foreground">{stockText}</p>
               </div>
             </DraftCard>
           )

--- a/src/app/_components/stock/material-stock-simulator.tsx
+++ b/src/app/_components/stock/material-stock-simulator.tsx
@@ -82,14 +82,14 @@ export function MaterialStockSimulator({ data, materialStocks, masterStocksLoade
         {!selectedProductId ? (
           <p className="text-sm text-muted-foreground">商品を選択してください。</p>
         ) : rows.length === 0 ? (
-          <p className="text-sm text-muted-foreground">この商品に使用率が設定された材料費明細がありません。</p>
+          <p className="text-sm text-muted-foreground">この商品に使用量が設定された材料費明細がありません。</p>
         ) : (
           <div className="relative w-full overflow-x-auto overscroll-x-contain touch-pan-x">
             <Table className="min-w-[640px]">
               <TableHeader>
                 <TableRow>
                   <TableHead>材料</TableHead>
-                  <TableHead className="text-right">使用率</TableHead>
+                  <TableHead className="text-right">使用量入力値</TableHead>
                   <TableHead className="text-right">1個分消費量</TableHead>
                   <TableHead className="text-right">{displayCount}個分消費量</TableHead>
                   {isAuthenticated && (
@@ -109,7 +109,11 @@ export function MaterialStockSimulator({ data, materialStocks, masterStocksLoade
                     <TableRow key={row.materialId} className={row.isLow ? "bg-destructive/5" : undefined}>
                       <TableCell className="font-medium">{row.materialName}</TableCell>
                       <TableCell className="text-right text-muted-foreground">
-                        {row.usageRatioTotal !== null ? `${row.usageRatioTotal}%` : "-"}
+                        {row.usageInputTotal !== null
+                          ? row.usePercentageMode
+                            ? `${row.usageInputTotal}%`
+                            : `${row.usageInputTotal} ${row.unit}`
+                          : "-"}
                       </TableCell>
                       <TableCell className="text-right">
                         {row.usagePerProduct !== null

--- a/src/app/api/bulk-sync/apply/route.ts
+++ b/src/app/api/bulk-sync/apply/route.ts
@@ -100,6 +100,20 @@ export async function POST(request: Request) {
         return NextResponse.json({ error: "Failed to apply bulk sync" }, { status: 500 })
       }
 
+      const materialModes = (prepared.payload.materials as Array<{ id?: string; use_percentage_mode?: boolean }> | undefined)
+        ?.flatMap((item) =>
+          item.id
+            ? [{ user_id: user.id, id: item.id, use_percentage_mode: Boolean(item.use_percentage_mode ?? false) }]
+            : []
+        ) ?? []
+      if (materialModes.length > 0) {
+        const { error: modeError } = await supabase.from("materials").upsert(materialModes, { onConflict: "user_id,id" })
+        if (modeError) {
+          console.error("Failed to apply material mode flags", modeError)
+          return NextResponse.json({ error: "Failed to apply material mode flags" }, { status: 500 })
+        }
+      }
+
       await applyStockUpserts(supabase, user.id, prepared.stockUpserts)
 
       if (options.recordAuditLog) {

--- a/src/app/api/bulk-sync/import/route.ts
+++ b/src/app/api/bulk-sync/import/route.ts
@@ -133,6 +133,20 @@ export async function POST(request: Request) {
         return NextResponse.json({ error: "Failed to apply bulk sync import" }, { status: 500 })
       }
 
+      const materialModes = (prepared.payload.materials as Array<{ id?: string; use_percentage_mode?: boolean }> | undefined)
+        ?.flatMap((item) =>
+          item.id
+            ? [{ user_id: user.id, id: item.id, use_percentage_mode: Boolean(item.use_percentage_mode ?? false) }]
+            : []
+        ) ?? []
+      if (materialModes.length > 0) {
+        const { error: modeError } = await supabase.from("materials").upsert(materialModes, { onConflict: "user_id,id" })
+        if (modeError) {
+          console.error("Failed to apply material mode flags (import)", modeError)
+          return NextResponse.json({ error: "Failed to apply material mode flags" }, { status: 500 })
+        }
+      }
+
       await applyStockUpserts(supabase, user.id, prepared.stockUpserts)
 
       if (options.recordAuditLog) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -851,6 +851,9 @@ export default function Home() {
           <ProductTab
             data={data}
             actions={actions}
+            materialStocks={materialStocks}
+            masterStocksLoaded={masterStocksLoaded}
+            isAuthenticated={isAuthenticated}
             onSetStock={setStock}
             editingProductId={editingProductId}
             onRequestEditClear={() => setEditingProductId(null)}

--- a/src/lib/app-data-sync.ts
+++ b/src/lib/app-data-sync.ts
@@ -67,6 +67,7 @@ type MaterialRow = {
   size_description: string | null
   currency: string | null
   unit_cost: number | null
+  use_percentage_mode: boolean | null
   supplier: string | null
   note: string | null
   units_per_batch: number | null
@@ -297,6 +298,7 @@ export async function loadUserAppData(userId: string): Promise<AppData | null> {
       sizeDescription: row.size_description ?? "",
       currency: row.currency ?? "JPY",
       unitCost: Number(row.unit_cost ?? 0),
+      usePercentageMode: Boolean(row.use_percentage_mode ?? false),
       supplier: row.supplier ?? undefined,
       note: row.note ?? undefined,
       unitsPerBatch: row.units_per_batch ?? undefined,
@@ -526,6 +528,7 @@ function buildSyncPayload(data: AppData, previous?: AppData) {
       size_description: item.sizeDescription,
       currency: item.currency,
       unit_cost: item.unitCost,
+      use_percentage_mode: Boolean(item.usePercentageMode ?? false),
       supplier: item.supplier ?? null,
       note: item.note ?? null,
       units_per_batch: item.unitsPerBatch ?? null,
@@ -813,6 +816,18 @@ export async function saveUserAppData(userId: string, data: AppData, previousDat
     })
     if (error) {
       throw error
+    }
+
+    const materialModeRows = data.materials.map((item) => ({
+      user_id: userId,
+      id: item.id,
+      use_percentage_mode: Boolean(item.usePercentageMode ?? false),
+    }))
+    if (materialModeRows.length > 0) {
+      const { error: modeError } = await supabaseClient
+        .from("materials")
+        .upsert(materialModeRows, { onConflict: "user_id,id" })
+      if (modeError) throw modeError
     }
 
     const audit = buildAuditMetadata(data, previousData)

--- a/src/lib/app-data.ts
+++ b/src/lib/app-data.ts
@@ -419,24 +419,60 @@ export function useAppData() {
     }
   }, [remoteLoadCompleted, authState.status, refreshStocks, refreshMasterStocks])
 
-  const setStock = useCallback(
-    async (productId: string, quantity: number) => {
+  const consumeMaterialsForProductIncrease = useCallback(
+    async (productId: string, deltaQuantity: number) => {
       if (authState.status !== "authenticated") return
-      await upsertProductStock(authState.user.id, productId, quantity)
-      setStocks((prev) => {
-        const next = new Map(prev)
-        next.set(productId, quantity)
-        return next
+      if (deltaQuantity <= 0) return
+
+      const productEntries = dataRef.current.costEntries.materials.filter((entry) => entry.productId === productId)
+      if (productEntries.length === 0) return
+
+      const materialById = new Map(dataRef.current.materials.map((item) => [item.id, item]))
+      const consumeMap = new Map<string, number>()
+      productEntries.forEach((entry) => {
+        const material = materialById.get(entry.materialId)
+        if (!material) return
+        const usage = Math.max(Number(entry.usageRatio) || 0, 0)
+        const perProduct = material.usePercentageMode ? usage / 100 : usage
+        if (perProduct <= 0) return
+        consumeMap.set(entry.materialId, (consumeMap.get(entry.materialId) ?? 0) + perProduct * deltaQuantity)
       })
+      if (consumeMap.size === 0) return
+
+      const insufficient: string[] = []
+      for (const [materialId, consumeAmount] of consumeMap.entries()) {
+        const current = materialStocksRef.current.get(materialId) ?? 0
+        const next = current - consumeAmount
+        const material = materialById.get(materialId)
+        if (next < 0 && material) {
+          insufficient.push(material.name)
+        }
+        await upsertMaterialStock(authState.user.id, materialId, next)
+        setMaterialStocks((prev) => {
+          const map = new Map(prev)
+          map.set(materialId, next)
+          return map
+        })
+      }
+
+      if (insufficient.length > 0) {
+        toast.warning("材料在庫が不足しています", {
+          description: `${insufficient.join("、")} が不足しています。マイナス在庫で継続しました。`,
+        })
+      }
     },
     [authState]
   )
 
-  const adjustStock = useCallback(
-    async (productId: string, delta: number) => {
+  const setStock = useCallback(
+    async (productId: string, quantity: number) => {
       if (authState.status !== "authenticated") return
       const current = stocksRef.current.get(productId) ?? 0
-      const next = Math.max(0, current + delta)
+      const next = Math.max(0, quantity)
+      const increase = Math.max(0, next - current)
+      if (increase > 0) {
+        await consumeMaterialsForProductIncrease(productId, increase)
+      }
       await upsertProductStock(authState.user.id, productId, next)
       setStocks((prev) => {
         const map = new Map(prev)
@@ -444,7 +480,26 @@ export function useAppData() {
         return map
       })
     },
-    [authState]
+    [authState, consumeMaterialsForProductIncrease]
+  )
+
+  const adjustStock = useCallback(
+    async (productId: string, delta: number) => {
+      if (authState.status !== "authenticated") return
+      const current = stocksRef.current.get(productId) ?? 0
+      const next = Math.max(0, current + delta)
+      const increase = Math.max(0, next - current)
+      if (increase > 0) {
+        await consumeMaterialsForProductIncrease(productId, increase)
+      }
+      await upsertProductStock(authState.user.id, productId, next)
+      setStocks((prev) => {
+        const map = new Map(prev)
+        map.set(productId, next)
+        return map
+      })
+    },
+    [authState, consumeMaterialsForProductIncrease]
   )
 
   useEffect(() => {

--- a/src/lib/bulk-sync/apply.ts
+++ b/src/lib/bulk-sync/apply.ts
@@ -393,6 +393,7 @@ export const prepareBulkSyncApply = (
           size_description: record.data.size_description ?? null,
           currency: record.data.currency ?? "JPY",
           unit_cost: record.data.unit_cost ?? null,
+          use_percentage_mode: Boolean(record.data.use_percentage_mode ?? false),
           supplier: record.data.supplier ?? null,
           note: record.data.note ?? null,
           units_per_batch: record.data.units_per_batch ?? null,

--- a/src/lib/bulk-sync/sheet-columns.ts
+++ b/src/lib/bulk-sync/sheet-columns.ts
@@ -26,6 +26,7 @@ export const SHEET_COLUMNS: Record<BulkSyncEntity, string[]> = {
     "currency",
     "unit_cost",
     "units_per_batch",
+    "use_percentage_mode",
     "supplier",
     "note",
     "stock",

--- a/src/lib/bulk-sync/sheet-export.ts
+++ b/src/lib/bulk-sync/sheet-export.ts
@@ -58,6 +58,7 @@ export const buildBulkSyncSheetRows = (data: AppData, stocks?: StockMaps) => {
       item.currency,
       item.unitCost,
       item.unitsPerBatch ?? "",
+      item.usePercentageMode ? "true" : "false",
       item.supplier ?? "",
       item.note ?? "",
       stocks?.materialStocks?.get(item.id) ?? "",

--- a/src/lib/bulk-sync/snapshot.ts
+++ b/src/lib/bulk-sync/snapshot.ts
@@ -77,6 +77,7 @@ export const buildSyncPayloadFromAppData = (data: AppData, previous?: AppData): 
       size_description: item.sizeDescription,
       currency: item.currency,
       unit_cost: item.unitCost,
+      use_percentage_mode: Boolean(item.usePercentageMode ?? false),
       supplier: item.supplier ?? null,
       note: item.note ?? null,
       units_per_batch: item.unitsPerBatch ?? null,

--- a/src/lib/bulk-sync/types.ts
+++ b/src/lib/bulk-sync/types.ts
@@ -59,9 +59,11 @@ export type MaterialInput = {
   currency?: string
   unit_cost?: number | string
   units_per_batch?: number | string
+  use_percentage_mode?: boolean | string
   supplier?: string
   note?: string
   stock?: number | string
+  stock_unit?: string
   is_deleted?: boolean
 }
 

--- a/src/lib/bulk-sync/validation.ts
+++ b/src/lib/bulk-sync/validation.ts
@@ -345,6 +345,7 @@ export const validateBulkSyncPayload = (payload: BulkSyncPayload, existing: AppD
 
     const materialStock = asNumber(item.stock)
     const materialStockUnit = asOptionalString(item.stock_unit)
+    const usePercentageMode = asBoolean(item.use_percentage_mode)
 
     pushRecord({
       entity: "materials",
@@ -358,6 +359,7 @@ export const validateBulkSyncPayload = (payload: BulkSyncPayload, existing: AppD
         currency: asOptionalString(item.currency) ?? "JPY",
         unit_cost: Number.isFinite(unitCost) ? unitCost : undefined,
         units_per_batch: Number.isFinite(unitsPerBatch) ? unitsPerBatch : undefined,
+        use_percentage_mode: usePercentageMode,
         supplier,
         note: asOptionalString(item.note),
         stock: Number.isFinite(materialStock) ? materialStock : undefined,

--- a/src/lib/calculations.ts
+++ b/src/lib/calculations.ts
@@ -6,7 +6,8 @@ export type MaterialConsumptionRow = {
   materialId: string
   materialName: string
   unit: string
-  usageRatioTotal: number | null
+  usageInputTotal: number | null
+  usePercentageMode: boolean
   usagePerProduct: number | null
   totalConsumption: number | null
   currentStock: number | null
@@ -21,7 +22,7 @@ export function calcMaterialConsumption(
   data: AppData,
   materialStocks: Map<string, number>
 ): MaterialConsumptionRow[] {
-  const grouped = new Map<string, { usageRatioTotal: number; material: (typeof data.materials)[0] }>()
+  const grouped = new Map<string, { usageInputTotal: number; material: (typeof data.materials)[0] }>()
 
   data.costEntries.materials
     .filter((entry) => entry.productId === productId && entry.usageRatio !== undefined)
@@ -30,15 +31,14 @@ export function calcMaterialConsumption(
       if (!material) return
       const existing = grouped.get(material.id)
       if (existing) {
-        existing.usageRatioTotal += entry.usageRatio!
+        existing.usageInputTotal += entry.usageRatio!
       } else {
-        grouped.set(material.id, { usageRatioTotal: entry.usageRatio!, material })
+        grouped.set(material.id, { usageInputTotal: entry.usageRatio!, material })
       }
     })
 
-  return Array.from(grouped.values()).map(({ usageRatioTotal, material }) => {
-    const unitsPerBatch = material.unitsPerBatch ?? 1
-    const usagePerProduct = (usageRatioTotal / 100) * unitsPerBatch
+  return Array.from(grouped.values()).map(({ usageInputTotal, material }) => {
+    const usagePerProduct = material.usePercentageMode ? usageInputTotal / 100 : usageInputTotal
     const totalConsumption = productionCount * usagePerProduct
     const hasStock = materialStocks.has(material.id)
     const currentStock = hasStock ? (materialStocks.get(material.id) ?? 0) : null
@@ -53,7 +53,8 @@ export function calcMaterialConsumption(
       materialId: material.id,
       materialName: material.name,
       unit: material.unit,
-      usageRatioTotal,
+      usageInputTotal,
+      usePercentageMode: Boolean(material.usePercentageMode),
       usagePerProduct,
       totalConsumption,
       currentStock,

--- a/src/lib/server/load-app-data.ts
+++ b/src/lib/server/load-app-data.ts
@@ -65,6 +65,7 @@ export const loadUserAppDataServer = async (supabase: SupabaseClient, userId: st
       currency: row.currency ?? "JPY",
       unitCost: row.unit_cost ?? 0,
       unitsPerBatch: row.units_per_batch ?? undefined,
+      usePercentageMode: Boolean(row.use_percentage_mode ?? false),
       supplier: row.supplier ?? undefined,
       note: row.note ?? undefined,
     })),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -26,6 +26,7 @@ export type Material = {
   currency: string
   unitCost: number
   unitsPerBatch?: number
+  usePercentageMode?: boolean
   supplier?: string
   note?: string
 }

--- a/supabase/migrations/20260306_material_use_percentage_mode.sql
+++ b/supabase/migrations/20260306_material_use_percentage_mode.sql
@@ -1,0 +1,2 @@
+alter table materials
+  add column if not exists use_percentage_mode boolean not null default false;


### PR DESCRIPTION
## 概要
- 材料マスタに `usePercentageMode`（パーセント指定モード）を追加
- 商品登録の材料費入力をモード連動に変更（単位数入力 / %入力）
- 商品登録フォームで材料選択時に在庫表示を追加
- 商品在庫の増加時（+ / 直接設定 / 新規登録初期在庫）に材料在庫を自動消費
- 材料在庫不足時は警告トーストを表示しつつマイナス在庫を許可
- スプシ連携に `use_percentage_mode` 列の書き出し/読み込み/適用を追加

## 変更ファイル
- `supabase/migrations/20260306_material_use_percentage_mode.sql`
- `src/lib/types.ts`
- `src/lib/app-data.ts`
- `src/lib/app-data-sync.ts`
- `src/lib/server/load-app-data.ts`
- `src/app/_components/master/sections/material/material-section.tsx`
- `src/app/_components/master/sections/material/material-list-section.tsx`
- `src/app/_components/product/sections/material-cost-section.tsx`
- `src/app/_components/product/product-tab.tsx`
- `src/app/_components/product/product-form-panel.tsx`
- `src/app/_components/product/hooks/use-product-form.ts`
- `src/app/_components/product/hooks/use-product-drafts.ts`
- `src/app/_components/stock/material-stock-simulator.tsx`
- `src/app/_components/cost/sections/material-usage-section.tsx`
- `src/lib/calculations.ts`
- `src/lib/bulk-sync/sheet-columns.ts`
- `src/lib/bulk-sync/sheet-export.ts`
- `src/lib/bulk-sync/validation.ts`
- `src/lib/bulk-sync/types.ts`
- `src/lib/bulk-sync/apply.ts`
- `src/lib/bulk-sync/snapshot.ts`
- `src/app/api/bulk-sync/export/route.ts`（loadUserAppDataServer 経由で反映）
- `src/app/api/bulk-sync/apply/route.ts`
- `src/app/api/bulk-sync/import/route.ts`

## 受け入れ条件
- [x] 材料マスタに「パーセント指定モード」のチェックボックスがある
- [x] パーセント指定モードOFFの材料は、商品登録時に単位数で入力できる
- [x] パーセント指定モードONの材料は、商品登録時に%で入力できる
- [x] 商品登録フォームで材料選択時に現在の在庫数が表示される
- [x] 商品在庫を+1すると、使用材料の在庫が自動的に減る
- [x] 商品在庫を直接設定（0→10）すると、10個分の材料が消費される
- [x] 商品を新規登録時に在庫数を設定すると、その分の材料が消費される
- [x] 商品在庫を-1しても材料は戻らない
- [x] 材料在庫が不足する場合、警告が表示されるがマイナスになることを許可する

## スプシ連携対応
- [x] materialsシートに`use_percentage_mode`列を追加（書き出し対応）
- [x] materialsシートの`use_percentage_mode`列を読み込み時に反映
- [x] 変更範囲に以下を追加:
  - `src/lib/bulk-sync/sheet-columns.ts`
  - `src/lib/bulk-sync/sheet-export.ts`
  - `src/lib/bulk-sync/validation.ts`
  - `src/app/api/bulk-sync/export/route.ts`（loadUserAppDataServer経由）

## 動作確認
- `npm run lint` を実行
- ローカル環境では `eslint: command not found`（依存未導入）で実行不可

Closes #124
