### PR TITLE
#95 商品登録フォームを4ステップ化してナビゲーションを追加

### DIFF
--- a/src/app/_components/product/product-form-panel.tsx
+++ b/src/app/_components/product/product-form-panel.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { useState, type FormEvent } from "react"
+
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import type { AppActions } from "@/lib/app-data"
@@ -88,6 +90,32 @@ export function ProductFormPanel(props: ProductFormPanelProps) {
     handleCancelEdit,
   } = useProductFormState(props)
 
+  const [currentStep, setCurrentStep] = useState(1)
+  const totalSteps = 4
+  const stepDefinitions = [
+    { id: 1, title: "商品基本情報" },
+    { id: 2, title: "直接材料費" },
+    { id: 3, title: "製造コスト" },
+    { id: 4, title: "物流・販売コスト" },
+  ] as const
+
+  const handleStepBack = () => {
+    setCurrentStep((prev) => Math.max(1, prev - 1))
+  }
+
+  const handleStepNext = () => {
+    setCurrentStep((prev) => Math.min(totalSteps, prev + 1))
+  }
+
+  const handleFormSubmit = (event: FormEvent<HTMLFormElement>) => {
+    if (currentStep < totalSteps) {
+      event.preventDefault()
+      handleStepNext()
+      return
+    }
+    handleSubmit(event)
+  }
+
   return (
     <div className="space-y-6">
       {editingProductId && (
@@ -103,106 +131,151 @@ export function ProductFormPanel(props: ProductFormPanelProps) {
         <CardHeader>
           <CardTitle>商品登録フォーム</CardTitle>
           <CardDescription>カテゴリ・想定生産量・制作工数・オプション（名称＋個数）・備考を設定します。</CardDescription>
+          <ol className="grid gap-2 text-xs sm:grid-cols-4">
+            {stepDefinitions.map((step) => {
+              const isActive = currentStep === step.id
+              const isCompleted = currentStep > step.id
+              return (
+                <li
+                  key={step.id}
+                  className={`rounded-md border px-2 py-2 ${
+                    isActive
+                      ? "border-primary bg-primary/10 font-semibold text-foreground"
+                      : isCompleted
+                        ? "border-emerald-500/40 bg-emerald-500/5 text-foreground"
+                        : "border-border text-muted-foreground"
+                  }`}
+                >
+                  <p className="text-[11px]">Step {step.id}</p>
+                  <p>{step.title}</p>
+                </li>
+              )
+            })}
+          </ol>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="grid gap-6 lg:grid-cols-[minmax(0,2.6fr)_minmax(280px,1fr)]">
-            <form className="order-2 space-y-6 lg:order-1" onSubmit={handleSubmit}>
-              <FormSection title="商品基本情報" description="カテゴリ・生産計画・販売価格・備考を設定" defaultOpen>
-                <ProductBasicsSection
-                  data={data}
-                  productForm={productForm}
-                  setProductForm={setProductForm}
-                  initialStock={initialStock}
-                  onInitialStockChange={setInitialStock}
-                  handleToggleEquipment={handleToggleEquipment}
-                />
-              </FormSection>
+            <form className="order-2 space-y-6 lg:order-1" onSubmit={handleFormSubmit}>
+              {currentStep === 1 && (
+                <FormSection title="商品基本情報" description="カテゴリ・生産計画・販売価格・備考を設定" defaultOpen>
+                  <ProductBasicsSection
+                    data={data}
+                    productForm={productForm}
+                    setProductForm={setProductForm}
+                    initialStock={initialStock}
+                    onInitialStockChange={setInitialStock}
+                    handleToggleEquipment={handleToggleEquipment}
+                  />
+                </FormSection>
+              )}
 
-              <div className="space-y-4">
-                <div>
-                  <p className="text-lg font-semibold">原価入力 (商品登録内)</p>
-                  <p className="text-sm text-muted-foreground">
-                    材料・梱包・人件費などをここで入力すると、原価確認タブには参照専用で反映されます。
-                  </p>
+              {currentStep === 2 && (
+                <div className="space-y-4">
+                  <div>
+                    <p className="text-lg font-semibold">原価入力 (商品登録内)</p>
+                    <p className="text-sm text-muted-foreground">
+                      材料・梱包・人件費などをここで入力すると、原価確認タブには参照専用で反映されます。
+                    </p>
+                  </div>
+                  <MaterialCostSection
+                    materials={data.materials}
+                    materialStocks={materialStocks}
+                    masterStocksLoaded={masterStocksLoaded}
+                    isAuthenticated={isAuthenticated}
+                    drafts={materialDrafts}
+                    onAdd={handleAddMaterialDraft}
+                    onUpdate={handleUpdateMaterialDraft}
+                    onRemove={handleRemoveMaterialDraft}
+                  />
+                  <PackagingCostSection
+                    items={data.packagingItems}
+                    drafts={packagingDrafts}
+                    onAdd={handleAddPackagingDraft}
+                    onUpdate={handleUpdatePackagingDraft}
+                    onRemove={handleRemovePackagingDraft}
+                  />
                 </div>
+              )}
 
-                <MaterialCostSection
-                  materials={data.materials}
-                  materialStocks={materialStocks}
-                  masterStocksLoaded={masterStocksLoaded}
-                  isAuthenticated={isAuthenticated}
-                  drafts={materialDrafts}
-                  onAdd={handleAddMaterialDraft}
-                  onUpdate={handleUpdateMaterialDraft}
-                  onRemove={handleRemoveMaterialDraft}
-                />
+              {currentStep === 3 && (
+                <div className="space-y-4">
+                  <div>
+                    <p className="text-lg font-semibold">製造コスト入力</p>
+                    <p className="text-sm text-muted-foreground">人件費・外注費・開発費・設備配賦を設定します。</p>
+                  </div>
+                  <LaborCostSection
+                    laborRoles={data.laborRoles}
+                    drafts={laborDrafts}
+                    onAdd={handleAddLaborDraft}
+                    onUpdate={handleUpdateLaborDraft}
+                    onRemove={handleRemoveLaborDraft}
+                  />
+                  <OutsourcingCostSection
+                    drafts={outsourcingDrafts}
+                    onAdd={handleAddOutsourcingDraft}
+                    onUpdate={handleUpdateOutsourcingDraft}
+                    onRemove={handleRemoveOutsourcingDraft}
+                  />
+                  <DevelopmentCostSection
+                    drafts={developmentDrafts}
+                    onAdd={handleAddDevelopmentDraft}
+                    onUpdate={handleUpdateDevelopmentDraft}
+                    onRemove={handleRemoveDevelopmentDraft}
+                  />
+                  <EquipmentAllocationSection
+                    equipments={data.equipments}
+                    drafts={equipmentAllocDrafts}
+                    totalUsageHours={totalEquipmentHours}
+                    hasSelectedEquipment={productForm.equipmentIds.length > 0}
+                    onUpdate={handleUpdateEquipmentDraft}
+                  />
+                </div>
+              )}
 
-                <PackagingCostSection
-                  items={data.packagingItems}
-                  drafts={packagingDrafts}
-                  onAdd={handleAddPackagingDraft}
-                  onUpdate={handleUpdatePackagingDraft}
-                  onRemove={handleRemovePackagingDraft}
-                />
+              {currentStep === 4 && (
+                <div className="space-y-4">
+                  <div>
+                    <p className="text-lg font-semibold">物流・販売コスト入力</p>
+                    <p className="text-sm text-muted-foreground">物流費・販売手数料・電気代を設定します。</p>
+                  </div>
+                  <LogisticsCostSection
+                    shippingMethods={shippingMethods}
+                    drafts={logisticsDrafts}
+                    onAdd={handleAddLogisticsDraft}
+                    onUpdate={handleUpdateLogisticsDraft}
+                    onRemove={handleRemoveLogisticsDraft}
+                  />
+                  <FeeCostSection
+                    fees={data.fees}
+                    salePrice={Number(productForm.salePrice) || 0}
+                    drafts={feeDrafts}
+                    onAdd={handleAddFeeDraft}
+                    onUpdate={handleUpdateFeeDraft}
+                    onRemove={handleRemoveFeeDraft}
+                  />
+                  <ElectricityCostSection
+                    drafts={electricityDrafts}
+                    onAdd={handleAddElectricityDraft}
+                    onUpdate={handleUpdateElectricityDraft}
+                    onRemove={handleRemoveElectricityDraft}
+                  />
+                </div>
+              )}
 
-                <LaborCostSection
-                  laborRoles={data.laborRoles}
-                  drafts={laborDrafts}
-                  onAdd={handleAddLaborDraft}
-                  onUpdate={handleUpdateLaborDraft}
-                  onRemove={handleRemoveLaborDraft}
-                />
-
-                <OutsourcingCostSection
-                  drafts={outsourcingDrafts}
-                  onAdd={handleAddOutsourcingDraft}
-                  onUpdate={handleUpdateOutsourcingDraft}
-                  onRemove={handleRemoveOutsourcingDraft}
-                />
-
-                <DevelopmentCostSection
-                  drafts={developmentDrafts}
-                  onAdd={handleAddDevelopmentDraft}
-                  onUpdate={handleUpdateDevelopmentDraft}
-                  onRemove={handleRemoveDevelopmentDraft}
-                />
-
-                <EquipmentAllocationSection
-                  equipments={data.equipments}
-                  drafts={equipmentAllocDrafts}
-                  totalUsageHours={totalEquipmentHours}
-                  hasSelectedEquipment={productForm.equipmentIds.length > 0}
-                  onUpdate={handleUpdateEquipmentDraft}
-                />
-
-                <LogisticsCostSection
-                  shippingMethods={shippingMethods}
-                  drafts={logisticsDrafts}
-                  onAdd={handleAddLogisticsDraft}
-                  onUpdate={handleUpdateLogisticsDraft}
-                  onRemove={handleRemoveLogisticsDraft}
-                />
-
-                <FeeCostSection
-                  fees={data.fees}
-                  salePrice={Number(productForm.salePrice) || 0}
-                  drafts={feeDrafts}
-                  onAdd={handleAddFeeDraft}
-                  onUpdate={handleUpdateFeeDraft}
-                  onRemove={handleRemoveFeeDraft}
-                />
-
-                <ElectricityCostSection
-                  drafts={electricityDrafts}
-                  onAdd={handleAddElectricityDraft}
-                  onUpdate={handleUpdateElectricityDraft}
-                  onRemove={handleRemoveElectricityDraft}
-                />
+              <div className="flex flex-wrap gap-2">
+                {currentStep > 1 && (
+                  <Button type="button" variant="outline" onClick={handleStepBack}>
+                    戻る
+                  </Button>
+                )}
+                {currentStep < totalSteps ? (
+                  <Button type="button" onClick={handleStepNext}>
+                    次へ
+                  </Button>
+                ) : (
+                  <Button type="submit">{editingProductId ? "商品を更新" : "商品を登録"}</Button>
+                )}
               </div>
-
-              <Button type="submit" className="w-fit">
-                {editingProductId ? "商品を更新" : "商品を登録"}
-              </Button>
             </form>
 
             <div className="order-1 lg:order-2">


### PR DESCRIPTION
## 概要\n- 商品登録フォームを4ステップに分割\n- Card上部にステップインジケーターを追加\n- フォーム下部に「戻る/次へ/登録(更新)」ナビゲーションを追加\n- 右カラムのリアルタイムサマリ表示は全ステップで維持\n\n## 変更ファイル\n- src/app/_components/product/product-form-panel.tsx\n\n## 確認\n- [x] Step 1 で戻るボタンが表示されない\n- [x] Step 1-3 は「次へ」でステップ遷移する\n- [x] Step 4 で「商品を登録/商品を更新」ボタンが表示される\n- [x] リアルタイムサマリが常時表示される\n\nCloses #95