### PR TITLE
#96 FieldHint未設定フィールドへインラインヒントを追加

### DIFF
--- a/src/app/_components/product/sections/development-cost-section.tsx
+++ b/src/app/_components/product/sections/development-cost-section.tsx
@@ -5,7 +5,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { NumberInput } from "@/components/ui/number-input"
 
-import { DraftCard, HintList, FormSection } from "../../shared/ui"
+import { DraftCard, FieldHint, HintList, FormSection } from "../../shared/ui"
 import type { DevelopmentCostDraft } from "../types"
 
 interface DevelopmentCostSectionProps {
@@ -64,6 +64,7 @@ export function DevelopmentCostSection({ drafts, onAdd, onUpdate, onRemove }: De
                     })
                   }
                 />
+                <FieldHint>試作・サンプル制作にかかった人件費の合計額</FieldHint>
               </div>
               <div className="space-y-1">
                 <Label className="text-xs text-muted-foreground">試作用材料費</Label>
@@ -76,6 +77,7 @@ export function DevelopmentCostSection({ drafts, onAdd, onUpdate, onRemove }: De
                     })
                   }
                 />
+                <FieldHint>試作で消費した素材・副資材の費用</FieldHint>
               </div>
             </div>
             <div className="grid gap-2 md:grid-cols-2">
@@ -90,6 +92,7 @@ export function DevelopmentCostSection({ drafts, onAdd, onUpdate, onRemove }: De
                     })
                   }
                 />
+                <FieldHint>型・治具など、この商品専用に購入したもの（1回限りのコスト）</FieldHint>
               </div>
               <div className="space-y-1">
                 <Label className="text-xs text-muted-foreground">償却年数</Label>
@@ -102,6 +105,9 @@ export function DevelopmentCostSection({ drafts, onAdd, onUpdate, onRemove }: De
                     })
                   }
                 />
+                <FieldHint>
+                  上記費用を何年で均等に原価計上するか（例: 2年なら毎年半額を原価に算入）
+                </FieldHint>
               </div>
             </div>
           </DraftCard>

--- a/src/app/_components/product/sections/material-cost-section.tsx
+++ b/src/app/_components/product/sections/material-cost-section.tsx
@@ -114,8 +114,8 @@ export function MaterialCostSection({
                     />
                     <FieldHint>
                       {usePercentageMode
-                        ? "100%で1単位消費します。例: 5%入力で0.05単位を消費。"
-                        : "1商品あたりの使用単位数を入力します。例: 2で2単位消費。"}
+                        ? "仕入れたロット全体のうち、1商品で使用する割合を % で入力（例: 1ロールの25%なら 25）"
+                        : "1商品あたりの使用単位数を入力します。"}
                     </FieldHint>
                   </div>
                   <div className="space-y-1">

--- a/src/app/_components/product/sections/outsourcing-cost-section.tsx
+++ b/src/app/_components/product/sections/outsourcing-cost-section.tsx
@@ -66,7 +66,7 @@ export function OutsourcingCostSection({ drafts, onAdd, onUpdate, onRemove }: Ou
                       })
                     }
                   />
-                  <FieldHint>1商品あたりの外注費。ロット費用を個数で割った値など。</FieldHint>
+                  <FieldHint>1商品を外注加工するときの費用（消費税の扱いを統一して入力）</FieldHint>
                 </div>
                 <div className="space-y-1">
                   <Label className="text-xs text-muted-foreground">通貨</Label>

--- a/src/app/_components/product/sections/packaging-cost-section.tsx
+++ b/src/app/_components/product/sections/packaging-cost-section.tsx
@@ -83,7 +83,7 @@ export function PackagingCostSection({ items, drafts, onAdd, onUpdate, onRemove 
                       })
                     }
                   />
-                  <FieldHint>1商品あたりに必要な点数。箱1つなら1、緩衝材を2枚使うなら2。</FieldHint>
+                  <FieldHint>1商品に使う点数・個数（箱なら1、テープなら1本分など）</FieldHint>
                 </div>
               </div>
               <p className="text-xs text-muted-foreground">梱包材単価: {unitCostLabel}</p>


### PR DESCRIPTION
## 概要
- 各コストセクションの対象7フィールドに `FieldHint` を追加・調整
- 既存の `FieldHint` コンポーネントを利用し、説明テキストの統一感を維持
- 入力・計算ロジックには変更なし（テキスト追加/更新のみ）

## 変更ファイル
- src/app/_components/product/sections/material-cost-section.tsx
- src/app/_components/product/sections/packaging-cost-section.tsx
- src/app/_components/product/sections/outsourcing-cost-section.tsx
- src/app/_components/product/sections/development-cost-section.tsx

## 対応内容
- 材料費: 使用率フィールドのヒント文言を追加/調整
- 梱包材費: 数量フィールドのヒント文言を調整
- 外注費: 単価フィールドのヒント文言を調整
- 開発コスト: 試作工数コスト / 試作用材料費 / 道具費 / 償却年数にヒントを追加

## 確認
- [x] 対象7フィールドで `FieldHint` が表示される
- [x] 既存 `FieldHint` を使用している
- [x] 計算ロジック変更なし
- [x] `npx eslint` で対象4ファイルのLint通過

Closes #96
