### PR TITLE
materialsのmode更新をupdate化して23502エラーを解消

### DIFF
--- a/src/app/api/bulk-sync/apply/route.ts
+++ b/src/app/api/bulk-sync/apply/route.ts
@@ -102,15 +102,19 @@ export async function POST(request: Request) {
 
       const materialModes = (prepared.payload.materials as Array<{ id?: string; use_percentage_mode?: boolean }> | undefined)
         ?.flatMap((item) =>
-          item.id
-            ? [{ user_id: user.id, id: item.id, use_percentage_mode: Boolean(item.use_percentage_mode ?? false) }]
-            : []
+          item.id ? [{ id: item.id, use_percentage_mode: Boolean(item.use_percentage_mode ?? false) }] : []
         ) ?? []
       if (materialModes.length > 0) {
-        const { error: modeError } = await supabase.from("materials").upsert(materialModes, { onConflict: "user_id,id" })
-        if (modeError) {
-          console.error("Failed to apply material mode flags", modeError)
-          return NextResponse.json({ error: "Failed to apply material mode flags" }, { status: 500 })
+        for (const item of materialModes) {
+          const { error: modeError } = await supabase
+            .from("materials")
+            .update({ use_percentage_mode: item.use_percentage_mode })
+            .eq("user_id", user.id)
+            .eq("id", item.id)
+          if (modeError) {
+            console.error("Failed to apply material mode flags", modeError)
+            return NextResponse.json({ error: "Failed to apply material mode flags" }, { status: 500 })
+          }
         }
       }
 

--- a/src/app/api/bulk-sync/import/route.ts
+++ b/src/app/api/bulk-sync/import/route.ts
@@ -135,15 +135,19 @@ export async function POST(request: Request) {
 
       const materialModes = (prepared.payload.materials as Array<{ id?: string; use_percentage_mode?: boolean }> | undefined)
         ?.flatMap((item) =>
-          item.id
-            ? [{ user_id: user.id, id: item.id, use_percentage_mode: Boolean(item.use_percentage_mode ?? false) }]
-            : []
+          item.id ? [{ id: item.id, use_percentage_mode: Boolean(item.use_percentage_mode ?? false) }] : []
         ) ?? []
       if (materialModes.length > 0) {
-        const { error: modeError } = await supabase.from("materials").upsert(materialModes, { onConflict: "user_id,id" })
-        if (modeError) {
-          console.error("Failed to apply material mode flags (import)", modeError)
-          return NextResponse.json({ error: "Failed to apply material mode flags" }, { status: 500 })
+        for (const item of materialModes) {
+          const { error: modeError } = await supabase
+            .from("materials")
+            .update({ use_percentage_mode: item.use_percentage_mode })
+            .eq("user_id", user.id)
+            .eq("id", item.id)
+          if (modeError) {
+            console.error("Failed to apply material mode flags (import)", modeError)
+            return NextResponse.json({ error: "Failed to apply material mode flags" }, { status: 500 })
+          }
         }
       }
 

--- a/src/lib/app-data-sync.ts
+++ b/src/lib/app-data-sync.ts
@@ -819,14 +819,15 @@ export async function saveUserAppData(userId: string, data: AppData, previousDat
     }
 
     const materialModeRows = data.materials.map((item) => ({
-      user_id: userId,
       id: item.id,
       use_percentage_mode: Boolean(item.usePercentageMode ?? false),
     }))
-    if (materialModeRows.length > 0) {
+    for (const item of materialModeRows) {
       const { error: modeError } = await supabaseClient
         .from("materials")
-        .upsert(materialModeRows, { onConflict: "user_id,id" })
+        .update({ use_percentage_mode: item.use_percentage_mode })
+        .eq("user_id", userId)
+        .eq("id", item.id)
       if (modeError) throw modeError
     }
 


### PR DESCRIPTION
## 概要
- `materials.use_percentage_mode` 反映時の `upsert` を廃止し、`update + eq(user_id,id)` に変更
- insert経路を通らないようにして、`materials` のNOT NULL列不足による `23502` を回避

## 変更箇所
- src/lib/app-data-sync.ts
- src/app/api/bulk-sync/apply/route.ts
- src/app/api/bulk-sync/import/route.ts

## 背景
`on_conflict=user_id,id` 付き `upsert` が、対象行未存在時に insert となり、`name` 等の必須列を渡していないため `23502` が発生していた。

## 確認
- [x] 対象3ファイルの ESLint エラーなし
- [x] mode更新処理が insert を実行しない実装になっている
