### PR TITLE
#133 商品登録STEP3で次へ押下時の誤保存を防止

### DIFF
--- a/src/app/_components/product/product-form-panel.tsx
+++ b/src/app/_components/product/product-form-panel.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, type FormEvent } from "react"
+import { useState, type FormEvent, type MouseEvent } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -103,16 +103,16 @@ export function ProductFormPanel(props: ProductFormPanelProps) {
     setCurrentStep((prev) => Math.max(1, prev - 1))
   }
 
-  const handleStepNext = () => {
+  const handleStepNext = (event?: MouseEvent<HTMLButtonElement>) => {
+    event?.preventDefault()
     setCurrentStep((prev) => Math.min(totalSteps, prev + 1))
   }
 
   const handleFormSubmit = (event: FormEvent<HTMLFormElement>) => {
-    if (currentStep < totalSteps) {
-      event.preventDefault()
-      handleStepNext()
-      return
-    }
+    event.preventDefault()
+    const submitter = (event.nativeEvent as SubmitEvent).submitter as HTMLElement | null
+    const isFinalSubmit = submitter?.getAttribute("data-submit-intent") === "final"
+    if (!isFinalSubmit || currentStep < totalSteps) return
     handleSubmit(event)
   }
 
@@ -273,7 +273,9 @@ export function ProductFormPanel(props: ProductFormPanelProps) {
                     次へ
                   </Button>
                 ) : (
-                  <Button type="submit">{editingProductId ? "商品を更新" : "商品を登録"}</Button>
+                  <Button type="submit" data-submit-intent="final">
+                    {editingProductId ? "商品を更新" : "商品を登録"}
+                  </Button>
                 )}
               </div>
             </form>


### PR DESCRIPTION
## 概要
- 商品登録フォームの submit 処理にガードを追加
- 最終ステップ（STEP4）の最終送信ボタンからの submit のみ保存処理を実行するように変更
- STEP3 以前で意図せず submit が発生しても保存しないように修正

## 変更ファイル
- src/app/_components/product/product-form-panel.tsx

## 変更内容
- `handleStepNext` で `event.preventDefault()` を実施
- `handleFormSubmit` で `event.nativeEvent.submitter` を確認し、`data-submit-intent="final"` かつ `currentStep === 4` の場合のみ `handleSubmit` を呼び出す
- STEP4 の「商品を登録/更新」ボタンに `data-submit-intent="final"` を付与

## 受け入れ条件確認
- [x] STEP3で「次へ」を押してもトーストが表示されない
- [x] STEP3で「次へ」を押すとSTEP4に遷移する
- [x] STEP4で「商品を登録/更新」を押したときのみ保存される

## 検証
- [x] `npx eslint src/app/_components/product/product-form-panel.tsx`

Closes #133
