### PR TITLE
#135 材料一覧の現在残数表示を小数第1位で四捨五入

### DIFF
--- a/src/app/_components/master/sections/material/material-list-section.tsx
+++ b/src/app/_components/master/sections/material/material-list-section.tsx
@@ -27,6 +27,11 @@ interface MaterialListSectionProps {
   onAdjustMaterialStock: (id: string, delta: number) => Promise<void>
 }
 
+const formatStockQuantity = (quantity: number) => {
+  const rounded = Math.round((quantity + Number.EPSILON) * 10) / 10
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1)
+}
+
 export function MaterialListSection({ data, actions, createTempId, isAuthenticated, materialStocks, materialStockUnits, masterStocksLoaded, onSetMaterialStock, onAdjustMaterialStock }: MaterialListSectionProps) {
   const [editingMaterial, setEditingMaterial] = useState<Omit<Material, "id"> & { id: string | null }>({
     id: null,
@@ -377,7 +382,7 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
                             {!masterStocksLoaded
                               ? <span className="text-muted-foreground">-</span>
                               : materialStocks.has(material.id)
-                                ? `${materialStocks.get(material.id)} ${displayStockUnit}`
+                                ? `${formatStockQuantity(materialStocks.get(material.id) ?? 0)} ${displayStockUnit}`
                                 : <span className="text-muted-foreground">-</span>}
                           </button>
                         )}


### PR DESCRIPTION
## 概要
材料一覧の「現在残数」表示で浮動小数の誤差（例: `0.899999`）が見える問題を修正し、小数第1位で四捨五入して表示するようにしました。

## 変更ファイル
- src/app/_components/master/sections/material/material-list-section.tsx

## 変更内容
- 表示専用の `formatStockQuantity` ヘルパーを追加
- 在庫表示時に `Math.round(... * 10) / 10` で小数第1位四捨五入
- 端数がない場合は整数表示、端数がある場合は小数第1位で表示

## 受け入れ条件確認
- [x] 材料一覧の現在残数が小数第1位で四捨五入されて表示される
- [x] `0.899999` のような値が `0.9` と表示される

## 検証
- [x] `npx eslint src/app/_components/master/sections/material/material-list-section.tsx`

Closes #135
