### PR TITLE
#137 登録済みマスタ一覧に開閉機能を追加

### DIFF
--- a/src/app/_components/master/list/master-list-view.tsx
+++ b/src/app/_components/master/list/master-list-view.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
 import type { AppActions } from "@/lib/app-data"
 import type { AppData } from "@/lib/types"
 import { createTempId } from "@/lib/utils"
@@ -28,43 +31,132 @@ interface MasterListViewProps {
   onAdjustPackagingStock: (id: string, delta: number) => Promise<void>
 }
 
+type MasterListSectionKey =
+  | "category"
+  | "material"
+  | "packaging"
+  | "optionPreset"
+  | "shipping"
+  | "fee"
+  | "labor"
+  | "equipment"
+
+const defaultOpenState: Record<MasterListSectionKey, boolean> = {
+  category: true,
+  material: true,
+  packaging: true,
+  optionPreset: true,
+  shipping: true,
+  fee: true,
+  labor: true,
+  equipment: true,
+}
+
 export function MasterListView({ data, actions, isAuthenticated, materialStocks, materialStockUnits, packagingStocks, packagingStockUnits, masterStocksLoaded, onSetMaterialStock, onSetPackagingStock, onAdjustMaterialStock, onAdjustPackagingStock }: MasterListViewProps) {
+  const [openState, setOpenState] = useState<Record<MasterListSectionKey, boolean>>(defaultOpenState)
+
+  const setAllOpenState = (value: boolean) => {
+    setOpenState({
+      category: value,
+      material: value,
+      packaging: value,
+      optionPreset: value,
+      shipping: value,
+      fee: value,
+      labor: value,
+      equipment: value,
+    })
+  }
+
+  const toggleSection = (key: MasterListSectionKey) => {
+    setOpenState((prev) => ({ ...prev, [key]: !prev[key] }))
+  }
+
+  const renderSectionToggle = (key: MasterListSectionKey, label: string) => (
+    <div className="flex justify-end">
+      <Button type="button" size="sm" variant="ghost" onClick={() => toggleSection(key)}>
+        {label}を{openState[key] ? "閉じる" : "開く"}
+      </Button>
+    </div>
+  )
+
   return (
     <div className="space-y-6">
-      <CategoryListSection data={data} actions={actions} createTempId={createTempId} />
+      <div className="flex justify-end gap-2">
+        <Button type="button" size="sm" variant="outline" onClick={() => setAllOpenState(true)}>
+          全て開く
+        </Button>
+        <Button type="button" size="sm" variant="ghost" onClick={() => setAllOpenState(false)}>
+          全て閉じる
+        </Button>
+      </div>
 
-      <div className="space-y-6">
-        <MaterialListSection
-          data={data}
-          actions={actions}
-          createTempId={createTempId}
-          isAuthenticated={isAuthenticated}
-          materialStocks={materialStocks}
-          materialStockUnits={materialStockUnits}
-          masterStocksLoaded={masterStocksLoaded}
-          onSetMaterialStock={onSetMaterialStock}
-          onAdjustMaterialStock={onAdjustMaterialStock}
-        />
-
-        <PackagingListSection
-          data={data}
-          actions={actions}
-          createTempId={createTempId}
-          isAuthenticated={isAuthenticated}
-          packagingStocks={packagingStocks}
-          packagingStockUnits={packagingStockUnits}
-          masterStocksLoaded={masterStocksLoaded}
-          onSetPackagingStock={onSetPackagingStock}
-          onAdjustPackagingStock={onAdjustPackagingStock}
-        />
-        <OptionPresetListSection data={data} actions={actions} createTempId={createTempId} />
+      <div className="space-y-2">
+        {renderSectionToggle("category", "カテゴリ一覧")}
+        {openState.category && <CategoryListSection data={data} actions={actions} createTempId={createTempId} />}
       </div>
 
       <div className="space-y-6">
-        <ShippingListSection data={data} actions={actions} createTempId={createTempId} />
-        <FeeListSection data={data} actions={actions} createTempId={createTempId} />
-        <LaborListSection data={data} actions={actions} createTempId={createTempId} />
-        <EquipmentListSection data={data} actions={actions} createTempId={createTempId} />
+        <div className="space-y-2">
+          {renderSectionToggle("material", "材料一覧")}
+          {openState.material && (
+            <MaterialListSection
+              data={data}
+              actions={actions}
+              createTempId={createTempId}
+              isAuthenticated={isAuthenticated}
+              materialStocks={materialStocks}
+              materialStockUnits={materialStockUnits}
+              masterStocksLoaded={masterStocksLoaded}
+              onSetMaterialStock={onSetMaterialStock}
+              onAdjustMaterialStock={onAdjustMaterialStock}
+            />
+          )}
+        </div>
+
+        <div className="space-y-2">
+          {renderSectionToggle("packaging", "梱包材一覧")}
+          {openState.packaging && (
+            <PackagingListSection
+              data={data}
+              actions={actions}
+              createTempId={createTempId}
+              isAuthenticated={isAuthenticated}
+              packagingStocks={packagingStocks}
+              packagingStockUnits={packagingStockUnits}
+              masterStocksLoaded={masterStocksLoaded}
+              onSetPackagingStock={onSetPackagingStock}
+              onAdjustPackagingStock={onAdjustPackagingStock}
+            />
+          )}
+        </div>
+
+        <div className="space-y-2">
+          {renderSectionToggle("optionPreset", "オプション一覧")}
+          {openState.optionPreset && <OptionPresetListSection data={data} actions={actions} createTempId={createTempId} />}
+        </div>
+      </div>
+
+      <div className="space-y-6">
+        <div className="space-y-2">
+          {renderSectionToggle("shipping", "配送一覧")}
+          {openState.shipping && <ShippingListSection data={data} actions={actions} createTempId={createTempId} />}
+        </div>
+
+        <div className="space-y-2">
+          {renderSectionToggle("fee", "手数料一覧")}
+          {openState.fee && <FeeListSection data={data} actions={actions} createTempId={createTempId} />}
+        </div>
+
+        <div className="space-y-2">
+          {renderSectionToggle("labor", "人件費一覧")}
+          {openState.labor && <LaborListSection data={data} actions={actions} createTempId={createTempId} />}
+        </div>
+
+        <div className="space-y-2">
+          {renderSectionToggle("equipment", "設備一覧")}
+          {openState.equipment && <EquipmentListSection data={data} actions={actions} createTempId={createTempId} />}
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## 概要
登録済みマスタ一覧画面に、各一覧セクションごとの開閉ボタンと「全て開く / 全て閉じる」機能を追加しました。

## 変更ファイル
- src/app/_components/master/list/master-list-view.tsx

## 変更内容
- セクションごとの開閉状態を `MasterListView` で state 管理
- 画面上部に「全て開く」「全て閉じる」ボタンを追加
- 各一覧セクション直上に「開く/閉じる」ボタンを追加
- 開閉対象:
  - カテゴリ一覧
  - 材料一覧
  - 梱包材一覧
  - オプション一覧
  - 配送一覧
  - 手数料一覧
  - 人件費一覧
  - 設備一覧

## 受け入れ条件確認
- [x] 各一覧セクションに開閉ボタンがある
- [x] 開閉状態が切り替わる
- [x] 「全て開く」ボタンで全セクションが開く
- [x] 「全て閉じる」ボタンで全セクションが閉じる

## 検証
- [x] `npx eslint src/app/_components/master/list/master-list-view.tsx`

Closes #137
