### PR TITLE
#138 原価サマリにセクション開閉機能を追加

### DIFF
--- a/src/app/_components/cost/cost-tab.tsx
+++ b/src/app/_components/cost/cost-tab.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
 import type { AppData } from "@/lib/types"
 
 import { CostSummarySection } from "./sections/cost-summary-section"
@@ -13,20 +16,89 @@ interface CostTabProps {
   data: AppData
 }
 
+type CostSectionKey =
+  | "summary"
+  | "profitSimulation"
+  | "packaging"
+  | "laborOutsourcing"
+  | "developmentEquipment"
+  | "logisticsElectricity"
+
+const defaultOpenState: Record<CostSectionKey, boolean> = {
+  summary: true,
+  profitSimulation: true,
+  packaging: true,
+  laborOutsourcing: true,
+  developmentEquipment: true,
+  logisticsElectricity: true,
+}
+
 export function CostTab({ data }: CostTabProps) {
+  const [openState, setOpenState] = useState<Record<CostSectionKey, boolean>>(defaultOpenState)
+
+  const setAllOpenState = (value: boolean) => {
+    setOpenState({
+      summary: value,
+      profitSimulation: value,
+      packaging: value,
+      laborOutsourcing: value,
+      developmentEquipment: value,
+      logisticsElectricity: value,
+    })
+  }
+
+  const toggleSection = (key: CostSectionKey) => {
+    setOpenState((prev) => ({ ...prev, [key]: !prev[key] }))
+  }
+
+  const renderSectionToggle = (key: CostSectionKey, label: string) => (
+    <div className="flex justify-end">
+      <Button type="button" size="sm" variant="ghost" onClick={() => toggleSection(key)}>
+        {label}を{openState[key] ? "閉じる" : "開く"}
+      </Button>
+    </div>
+  )
+
   return (
     <div className="space-y-6">
-      <CostSummarySection data={data} />
+      <div className="flex justify-end gap-2">
+        <Button type="button" size="sm" variant="outline" onClick={() => setAllOpenState(true)}>
+          全て開く
+        </Button>
+        <Button type="button" size="sm" variant="ghost" onClick={() => setAllOpenState(false)}>
+          全て閉じる
+        </Button>
+      </div>
 
-      <ProfitSimulationSection data={data} />
+      <div className="space-y-2">
+        {renderSectionToggle("summary", "原価サマリ")}
+        {openState.summary && <CostSummarySection data={data} />}
+      </div>
 
-      <PackagingCostSection data={data} />
+      <div className="space-y-2">
+        {renderSectionToggle("profitSimulation", "利益シミュレーション")}
+        {openState.profitSimulation && <ProfitSimulationSection data={data} />}
+      </div>
 
-      <LaborOutsourcingSection data={data} />
+      <div className="space-y-2">
+        {renderSectionToggle("packaging", "梱包コスト集計")}
+        {openState.packaging && <PackagingCostSection data={data} />}
+      </div>
 
-      <DevelopmentEquipmentSection data={data} />
+      <div className="space-y-2">
+        {renderSectionToggle("laborOutsourcing", "人件費・外注費集計")}
+        {openState.laborOutsourcing && <LaborOutsourcingSection data={data} />}
+      </div>
 
-      <LogisticsElectricitySection data={data} />
+      <div className="space-y-2">
+        {renderSectionToggle("developmentEquipment", "開発・設備コスト")}
+        {openState.developmentEquipment && <DevelopmentEquipmentSection data={data} />}
+      </div>
+
+      <div className="space-y-2">
+        {renderSectionToggle("logisticsElectricity", "物流・電力コスト")}
+        {openState.logisticsElectricity && <LogisticsElectricitySection data={data} />}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## 概要
原価サマリタブの各セクションに開閉機能を追加し、あわせて「全て開く / 全て閉じる」を実装しました。

## 変更ファイル
- src/app/_components/cost/cost-tab.tsx

## 変更内容
- 各セクションの開閉状態を `cost-tab.tsx` で state 管理
- 上部に「全て開く」「全て閉じる」ボタンを追加
- 各セクションごとに「開く/閉じる」ボタンを追加
- 対象セクション:
  - 原価サマリ
  - 利益シミュレーション
  - 梱包コスト集計
  - 人件費・外注費集計
  - 開発・設備コスト
  - 物流・電力コスト

## 受け入れ条件確認
- [x] 原価サマリの各セクションに開閉ボタンがある
- [x] 開閉状態が切り替わる
- [x] 「全て開く」ボタンで全セクションが開く
- [x] 「全て閉じる」ボタンで全セクションが閉じる

## 検証
- [x] `npx eslint src/app/_components/cost/cost-tab.tsx`

Closes #138
