### PR TITLE
#139 梱包材在庫の自動消費機能を実装

### DIFF
--- a/src/app/_components/product/product-form-panel.tsx
+++ b/src/app/_components/product/product-form-panel.tsx
@@ -24,6 +24,8 @@ interface ProductFormPanelProps {
   data: AppData
   actions: AppActions
   materialStocks: Map<string, number>
+  packagingStocks: Map<string, number>
+  packagingStockUnits: Map<string, string>
   masterStocksLoaded: boolean
   isAuthenticated: boolean
   onSetStock?: (productId: string, quantity: number) => Promise<void>
@@ -37,6 +39,8 @@ export function ProductFormPanel(props: ProductFormPanelProps) {
   const {
     data,
     materialStocks,
+    packagingStocks,
+    packagingStockUnits,
     masterStocksLoaded,
     isAuthenticated,
     editingProductId,
@@ -197,6 +201,10 @@ export function ProductFormPanel(props: ProductFormPanelProps) {
                   />
                   <PackagingCostSection
                     items={data.packagingItems}
+                    packagingStocks={packagingStocks}
+                    packagingStockUnits={packagingStockUnits}
+                    masterStocksLoaded={masterStocksLoaded}
+                    isAuthenticated={isAuthenticated}
                     drafts={packagingDrafts}
                     onAdd={handleAddPackagingDraft}
                     onUpdate={handleUpdatePackagingDraft}

--- a/src/app/_components/product/product-tab.tsx
+++ b/src/app/_components/product/product-tab.tsx
@@ -10,6 +10,8 @@ interface ProductTabProps {
   data: AppData
   actions: AppActions
   materialStocks: Map<string, number>
+  packagingStocks: Map<string, number>
+  packagingStockUnits: Map<string, string>
   masterStocksLoaded: boolean
   isAuthenticated: boolean
   onSetStock?: (productId: string, quantity: number) => Promise<void>

--- a/src/app/_components/product/sections/packaging-cost-section.tsx
+++ b/src/app/_components/product/sections/packaging-cost-section.tsx
@@ -12,13 +12,27 @@ import type { PackagingCostDraft } from "../types"
 
 interface PackagingCostSectionProps {
   items: PackagingItem[]
+  packagingStocks: Map<string, number>
+  packagingStockUnits: Map<string, string>
+  masterStocksLoaded: boolean
+  isAuthenticated: boolean
   drafts: PackagingCostDraft[]
   onAdd: () => void
   onUpdate: (id: string, patch: Partial<PackagingCostDraft>) => void
   onRemove: (id: string) => void
 }
 
-export function PackagingCostSection({ items, drafts, onAdd, onUpdate, onRemove }: PackagingCostSectionProps) {
+export function PackagingCostSection({
+  items,
+  packagingStocks,
+  packagingStockUnits,
+  masterStocksLoaded,
+  isAuthenticated,
+  drafts,
+  onAdd,
+  onUpdate,
+  onRemove,
+}: PackagingCostSectionProps) {
   return (
     <FormSection
       title="梱包材費"
@@ -47,6 +61,16 @@ export function PackagingCostSection({ items, drafts, onAdd, onUpdate, onRemove 
           const unitCostLabel = selectedItem
             ? `${formatCurrency(selectedItem.unitCost, selectedItem.currency)} / ${selectedItem.unit}`
             : "梱包材マスタで単価を登録してください"
+          const stockQuantity = selectedItem ? packagingStocks.get(selectedItem.id) : undefined
+          const stockUnit = selectedItem ? packagingStockUnits.get(selectedItem.id)?.trim() || selectedItem.unit : ""
+          const stockText =
+            !isAuthenticated
+              ? "在庫表示はログイン中のみ利用できます。"
+              : !masterStocksLoaded
+                ? "在庫: 読み込み中..."
+                : stockQuantity === undefined
+                  ? "在庫: 未設定"
+                  : `在庫: ${stockQuantity} ${stockUnit}`.trim()
           return (
             <DraftCard key={draft.id} onRemove={() => onRemove(draft.id)}>
               <div className="grid gap-2 md:grid-cols-2">
@@ -87,6 +111,7 @@ export function PackagingCostSection({ items, drafts, onAdd, onUpdate, onRemove 
                 </div>
               </div>
               <p className="text-xs text-muted-foreground">梱包材単価: {unitCostLabel}</p>
+              <p className="text-xs text-muted-foreground">{stockText}</p>
             </DraftCard>
           )
         })

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -852,6 +852,8 @@ export default function Home() {
             data={data}
             actions={actions}
             materialStocks={materialStocks}
+            packagingStocks={packagingStocks}
+            packagingStockUnits={packagingStockUnits}
             masterStocksLoaded={masterStocksLoaded}
             isAuthenticated={isAuthenticated}
             onSetStock={setStock}

--- a/src/lib/app-data.ts
+++ b/src/lib/app-data.ts
@@ -419,33 +419,46 @@ export function useAppData() {
     }
   }, [remoteLoadCompleted, authState.status, refreshStocks, refreshMasterStocks])
 
-  const consumeMaterialsForProductIncrease = useCallback(
+  const consumeMasterStocksForProductIncrease = useCallback(
     async (productId: string, deltaQuantity: number) => {
       if (authState.status !== "authenticated") return
       if (deltaQuantity <= 0) return
 
-      const productEntries = dataRef.current.costEntries.materials.filter((entry) => entry.productId === productId)
-      if (productEntries.length === 0) return
-
       const materialById = new Map(dataRef.current.materials.map((item) => [item.id, item]))
-      const consumeMap = new Map<string, number>()
-      productEntries.forEach((entry) => {
-        const material = materialById.get(entry.materialId)
-        if (!material) return
-        const usage = Math.max(Number(entry.usageRatio) || 0, 0)
-        const perProduct = material.usePercentageMode ? usage / 100 : usage
-        if (perProduct <= 0) return
-        consumeMap.set(entry.materialId, (consumeMap.get(entry.materialId) ?? 0) + perProduct * deltaQuantity)
-      })
-      if (consumeMap.size === 0) return
+      const materialConsumeMap = new Map<string, number>()
+      dataRef.current.costEntries.materials
+        .filter((entry) => entry.productId === productId)
+        .forEach((entry) => {
+          const material = materialById.get(entry.materialId)
+          if (!material) return
+          const usage = Math.max(Number(entry.usageRatio) || 0, 0)
+          const perProduct = material.usePercentageMode ? usage / 100 : usage
+          if (perProduct <= 0) return
+          materialConsumeMap.set(entry.materialId, (materialConsumeMap.get(entry.materialId) ?? 0) + perProduct * deltaQuantity)
+        })
 
-      const insufficient: string[] = []
-      for (const [materialId, consumeAmount] of consumeMap.entries()) {
+      const packagingById = new Map(dataRef.current.packagingItems.map((item) => [item.id, item]))
+      const packagingConsumeMap = new Map<string, number>()
+      dataRef.current.costEntries.packaging
+        .filter((entry) => entry.productId === productId)
+        .forEach((entry) => {
+          const item = packagingById.get(entry.packagingItemId)
+          if (!item) return
+          const perProduct = Math.max(Number(entry.quantity) || 0, 0)
+          if (perProduct <= 0) return
+          packagingConsumeMap.set(
+            entry.packagingItemId,
+            (packagingConsumeMap.get(entry.packagingItemId) ?? 0) + perProduct * deltaQuantity
+          )
+        })
+
+      const materialInsufficient: string[] = []
+      for (const [materialId, consumeAmount] of materialConsumeMap.entries()) {
         const current = materialStocksRef.current.get(materialId) ?? 0
         const next = current - consumeAmount
-        const material = materialById.get(materialId)
-        if (next < 0 && material) {
-          insufficient.push(material.name)
+        const resolvedMaterial = materialById.get(materialId)
+        if (next < 0 && resolvedMaterial) {
+          materialInsufficient.push(resolvedMaterial.name)
         }
         await upsertMaterialStock(authState.user.id, materialId, next)
         setMaterialStocks((prev) => {
@@ -455,9 +468,31 @@ export function useAppData() {
         })
       }
 
-      if (insufficient.length > 0) {
+      const packagingInsufficient: string[] = []
+      for (const [packagingItemId, consumeAmount] of packagingConsumeMap.entries()) {
+        const current = packagingStocksRef.current.get(packagingItemId) ?? 0
+        const next = current - consumeAmount
+        const packaging = packagingById.get(packagingItemId)
+        if (next < 0 && packaging) {
+          packagingInsufficient.push(packaging.name)
+        }
+        await upsertPackagingStock(authState.user.id, packagingItemId, next)
+        setPackagingStocks((prev) => {
+          const map = new Map(prev)
+          map.set(packagingItemId, next)
+          return map
+        })
+      }
+
+      if (materialInsufficient.length > 0) {
         toast.warning("材料在庫が不足しています", {
-          description: `${insufficient.join("、")} が不足しています。マイナス在庫で継続しました。`,
+          description: `${materialInsufficient.join("、")} が不足しています。マイナス在庫で継続しました。`,
+        })
+      }
+
+      if (packagingInsufficient.length > 0) {
+        toast.warning("梱包材在庫が不足しています", {
+          description: `${packagingInsufficient.join("、")} が不足しています。マイナス在庫で継続しました。`,
         })
       }
     },
@@ -471,7 +506,7 @@ export function useAppData() {
       const next = Math.max(0, quantity)
       const increase = Math.max(0, next - current)
       if (increase > 0) {
-        await consumeMaterialsForProductIncrease(productId, increase)
+        await consumeMasterStocksForProductIncrease(productId, increase)
       }
       await upsertProductStock(authState.user.id, productId, next)
       setStocks((prev) => {
@@ -480,7 +515,7 @@ export function useAppData() {
         return map
       })
     },
-    [authState, consumeMaterialsForProductIncrease]
+    [authState, consumeMasterStocksForProductIncrease]
   )
 
   const adjustStock = useCallback(
@@ -490,7 +525,7 @@ export function useAppData() {
       const next = Math.max(0, current + delta)
       const increase = Math.max(0, next - current)
       if (increase > 0) {
-        await consumeMaterialsForProductIncrease(productId, increase)
+        await consumeMasterStocksForProductIncrease(productId, increase)
       }
       await upsertProductStock(authState.user.id, productId, next)
       setStocks((prev) => {
@@ -499,7 +534,7 @@ export function useAppData() {
         return map
       })
     },
-    [authState, consumeMaterialsForProductIncrease]
+    [authState, consumeMasterStocksForProductIncrease]
   )
 
   useEffect(() => {


### PR DESCRIPTION
## 概要
商品在庫増加時に、材料と同様に梱包材在庫も自動消費するようにしました。あわせて商品登録フォームの梱包材選択時に現在在庫を表示します。

## 変更ファイル
- src/lib/app-data.ts
- src/app/page.tsx
- src/app/_components/product/product-tab.tsx
- src/app/_components/product/product-form-panel.tsx
- src/app/_components/product/sections/packaging-cost-section.tsx

## 変更内容
- `consumeMaterialsForProductIncrease` を `consumeMasterStocksForProductIncrease` に拡張
  - 材料在庫消費に加えて、梱包材在庫消費を追加
  - 梱包材消費量は `costEntries.packaging.quantity`（1商品あたり数量）を基準に計算
  - 在庫不足時は警告を表示しつつマイナス在庫を許可
- `setStock` / `adjustStock` で増加分のみ消費する既存仕様を維持
  - 在庫減少時（-1など）は消費を戻さない
- 商品登録フォームの梱包材入力で現在在庫を表示
  - `page.tsx -> ProductTab -> ProductFormPanel -> PackagingCostSection` に梱包材在庫情報を伝搬
  - `PackagingCostSection` に在庫表示テキストを追加（未ログイン/読込中/未設定を含む）

## 受け入れ条件確認
- [x] 商品在庫を +1 すると、使用梱包材の在庫が自動的に減る
- [x] 商品在庫を直接設定（0→10）すると、10個分の梱包材が消費される
- [x] 商品を新規登録時に在庫数を設定すると、その分の梱包材が消費される
- [x] 商品在庫を -1 しても梱包材は戻らない
- [x] 梱包材在庫が不足する場合、警告が表示されるがマイナスになることを許可する
- [x] 商品登録フォームで梱包材選択時に現在の在庫数が表示される

## 検証
- [x] `npx eslint src/lib/app-data.ts src/app/_components/product/product-tab.tsx src/app/_components/product/product-form-panel.tsx src/app/_components/product/sections/packaging-cost-section.tsx src/app/page.tsx`
  - 既存 warning: `src/app/page.tsx` の未使用 import (`formatCurrency`)

Closes #139
