### PR TITLE
#140 在庫一覧タブ新設とタブ順序カスタマイズを実装

### DIFF
--- a/src/app/_components/stock-list/stock-list-tab.tsx
+++ b/src/app/_components/stock-list/stock-list-tab.tsx
@@ -1,0 +1,153 @@
+"use client"
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import type { AppData } from "@/lib/types"
+
+type StockListTabProps = {
+  data: AppData
+  materialStocks: Map<string, number>
+  materialStockUnits: Map<string, string>
+  packagingStocks: Map<string, number>
+  packagingStockUnits: Map<string, string>
+  masterStocksLoaded: boolean
+  isAuthenticated: boolean
+}
+
+const formatStock = (quantity: number | undefined, unit: string) => {
+  if (quantity === undefined) return "未設定"
+  return `${quantity} ${unit}`.trim()
+}
+
+export function StockListTab({
+  data,
+  materialStocks,
+  materialStockUnits,
+  packagingStocks,
+  packagingStockUnits,
+  masterStocksLoaded,
+  isAuthenticated,
+}: StockListTabProps) {
+  const materialRows = data.materials.map((material) => ({
+    id: material.id,
+    name: material.name,
+    stock: materialStocks.get(material.id),
+    unit: materialStockUnits.get(material.id)?.trim() || material.unit,
+  }))
+
+  const packagingRows = data.packagingItems.map((item) => ({
+    id: item.id,
+    name: item.name,
+    stock: packagingStocks.get(item.id),
+    unit: packagingStockUnits.get(item.id)?.trim() || item.unit,
+  }))
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>在庫一覧</CardTitle>
+          <CardDescription>材料・梱包材・設備の在庫情報を確認できます。</CardDescription>
+        </CardHeader>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>材料在庫</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {!isAuthenticated ? (
+            <p className="text-sm text-muted-foreground">在庫表示はログイン中のみ利用できます。</p>
+          ) : !masterStocksLoaded ? (
+            <p className="text-sm text-muted-foreground">読み込み中...</p>
+          ) : materialRows.length === 0 ? (
+            <p className="text-sm text-muted-foreground">材料が登録されていません。</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>名称</TableHead>
+                    <TableHead className="text-right">現在残数</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {materialRows.map((row) => (
+                    <TableRow key={row.id}>
+                      <TableCell>{row.name}</TableCell>
+                      <TableCell className="text-right">{formatStock(row.stock, row.unit)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>梱包材在庫</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {!isAuthenticated ? (
+            <p className="text-sm text-muted-foreground">在庫表示はログイン中のみ利用できます。</p>
+          ) : !masterStocksLoaded ? (
+            <p className="text-sm text-muted-foreground">読み込み中...</p>
+          ) : packagingRows.length === 0 ? (
+            <p className="text-sm text-muted-foreground">梱包材が登録されていません。</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>名称</TableHead>
+                    <TableHead className="text-right">現在残数</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {packagingRows.map((row) => (
+                    <TableRow key={row.id}>
+                      <TableCell>{row.name}</TableCell>
+                      <TableCell className="text-right">{formatStock(row.stock, row.unit)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>設備一覧</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {data.equipments.length === 0 ? (
+            <p className="text-sm text-muted-foreground">設備が登録されていません。</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>設備名</TableHead>
+                    <TableHead className="text-right">設備在庫</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data.equipments.map((equipment) => (
+                    <TableRow key={equipment.id}>
+                      <TableCell>{equipment.name}</TableCell>
+                      <TableCell className="text-right">在庫管理対象外</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,8 +17,13 @@ import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useAppData } from "@/lib/app-data"
-import { loadProductListColumnSettings, upsertProductListColumnSettings } from "@/lib/app-data-sync"
-import { calculateProductUnitCosts, formatCurrency } from "@/lib/calculations"
+import {
+  loadProductListColumnSettings,
+  loadTabOrderSettings,
+  upsertProductListColumnSettings,
+  upsertTabOrderSettings,
+} from "@/lib/app-data-sync"
+import { calculateProductUnitCosts } from "@/lib/calculations"
 import type { AppData, AuditFilters, Product } from "@/lib/types"
 import { AnalyticsTab } from "./_components/analytics/analytics-tab"
 import { AuditTab } from "./_components/audit/audit-tab"
@@ -32,7 +37,7 @@ import {
   type ProductTableColumnSettings,
 } from "./_components/product-list/customizable-product-table"
 import { ProductTab } from "./_components/product/product-tab"
-import { StockTab } from "./_components/stock/stock-tab"
+import { StockListTab } from "./_components/stock-list/stock-list-tab"
 import { FileDown, FileUp, Menu, Plus } from "lucide-react"
 import { toast } from "sonner"
 import { useAuth } from "@/lib/auth"
@@ -43,10 +48,35 @@ const tabOptions = [
   { value: "product", label: "商品登録" },
   { value: "master", label: "マスタ登録" },
   { value: "list", label: "商品一覧" },
-  { value: "stock", label: "在庫" },
+  { value: "stock", label: "在庫一覧" },
   { value: "bulk", label: "一括処理" },
   { value: "audit", label: "監査ログ" },
-]
+] as const
+
+type TabValue = (typeof tabOptions)[number]["value"]
+
+const defaultTabOrder: TabValue[] = tabOptions.map((tab) => tab.value)
+
+const normalizeTabOrder = (raw: string[] | null | undefined): TabValue[] => {
+  const validSet = new Set<string>(defaultTabOrder)
+  const order = (Array.isArray(raw) ? raw : [])
+    .filter((value): value is TabValue => validSet.has(value))
+    .filter((value, index, array) => array.indexOf(value) === index)
+  defaultTabOrder.forEach((value) => {
+    if (!order.includes(value)) {
+      order.push(value)
+    }
+  })
+  return order
+}
+
+const moveTabBefore = (source: TabValue, target: TabValue, order: TabValue[]) => {
+  if (source === target) return order
+  const filtered = order.filter((value) => value !== source)
+  const index = filtered.indexOf(target)
+  if (index < 0) return order
+  return [...filtered.slice(0, index), source, ...filtered.slice(index)]
+}
 
 
 export default function Home() {
@@ -64,7 +94,6 @@ export default function Home() {
     updateAuditFilters,
     stocks,
     stocksLoaded,
-    refreshStocks,
     setStock,
     adjustStock,
     materialStocks,
@@ -96,6 +125,8 @@ export default function Home() {
   const [productCategorySmallFilter, setProductCategorySmallFilter] = useState<string | null>(null)
   const [productSortKey, setProductSortKey] = useState("registered-desc")
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
+  const [tabOrder, setTabOrder] = useState<TabValue[]>(defaultTabOrder)
+  const [draggingTab, setDraggingTab] = useState<TabValue | null>(null)
   const { state: authState, login, logout, signup, resetPassword } = useAuth()
   const isAuthenticated = authState.status === "authenticated"
   const [loginPanelOpen, setLoginPanelOpen] = useState(false)
@@ -111,6 +142,13 @@ export default function Home() {
   const backupImportInputRef = useRef<HTMLInputElement | null>(null)
   const importGuestData = actions.importGuestData
   const authUserId = authState.status === "authenticated" ? authState.user.id : null
+  const orderedTabOptions = useMemo(
+    () =>
+      tabOrder
+        .map((value) => tabOptions.find((tab) => tab.value === value))
+        .filter((tab): tab is (typeof tabOptions)[number] => Boolean(tab)),
+    [tabOrder]
+  )
   const productCostMap = useMemo(() => {
     const map = new Map<string, ReturnType<typeof calculateProductUnitCosts>>()
     data.products.forEach((product) => {
@@ -281,6 +319,11 @@ export default function Home() {
     }
     setMobileNavOpen(false)
   }, [])
+
+  useEffect(() => {
+    if (defaultTabOrder.includes(activeTab as TabValue)) return
+    handleTabChange("cost")
+  }, [activeTab, handleTabChange])
 
   const handleCreateProduct = useCallback(() => {
     setEditingProductId(null)
@@ -621,6 +664,53 @@ export default function Home() {
     }
   }, [authUserId])
 
+  useEffect(() => {
+    let cancelled = false
+    if (!authUserId) {
+      setTabOrder(defaultTabOrder)
+      return () => {
+        cancelled = true
+      }
+    }
+    ;(async () => {
+      try {
+        const loaded = await loadTabOrderSettings(authUserId)
+        if (cancelled) return
+        if (!loaded) {
+          setTabOrder(defaultTabOrder)
+          return
+        }
+        setTabOrder(normalizeTabOrder(loaded.tabOrder))
+      } catch (error) {
+        console.error("Failed to load tab order settings", error)
+        if (!cancelled) {
+          setTabOrder(defaultTabOrder)
+          toast.error("タブ順序の読み込みに失敗しました")
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [authUserId])
+
+  useEffect(() => {
+    if (!authUserId) return
+    void upsertTabOrderSettings(authUserId, tabOrder).catch((error) => {
+      console.error("Failed to save tab order settings", error)
+      toast.error("タブ順序の保存に失敗しました")
+    })
+  }, [authUserId, tabOrder])
+
+  const handleTabDrop = useCallback(
+    (target: TabValue) => {
+      if (!isAuthenticated || !draggingTab) return
+      setTabOrder((prev) => moveTabBefore(draggingTab, target, prev))
+      setDraggingTab(null)
+    },
+    [isAuthenticated, draggingTab]
+  )
+
   const renderLoading = () => (
     <main className="mx-auto flex min-h-screen max-w-4xl flex-col items-center justify-center gap-4 p-10 text-muted-foreground">
       <div className="h-10 w-10 animate-spin rounded-full border-4 border-muted border-t-transparent" />
@@ -812,12 +902,24 @@ export default function Home() {
               </Button>
             </div>
             <div className="space-y-2">
-              {tabOptions.map((tab) => (
+              {orderedTabOptions.map((tab) => (
                 <Button
                   key={tab.value}
                   type="button"
                   variant={activeTab === tab.value ? "secondary" : "outline"}
                   className="w-full justify-between"
+                  draggable={isAuthenticated}
+                  onDragStart={() => isAuthenticated && setDraggingTab(tab.value)}
+                  onDragEnd={() => setDraggingTab(null)}
+                  onDragOver={(event) => {
+                    if (!isAuthenticated || !draggingTab) return
+                    event.preventDefault()
+                  }}
+                  onDrop={(event) => {
+                    if (!isAuthenticated || !draggingTab) return
+                    event.preventDefault()
+                    handleTabDrop(tab.value)
+                  }}
                   onClick={() => handleTabChange(tab.value)}
                 >
                   {tab.label}
@@ -830,13 +932,26 @@ export default function Home() {
 
       <Tabs value={activeTab} onValueChange={handleTabChange}>
         <TabsList className="hidden md:inline-flex">
-          <TabsTrigger value="cost">原価サマリ</TabsTrigger>
-          <TabsTrigger value="analytics">集計データ</TabsTrigger>
-          <TabsTrigger value="product">商品登録</TabsTrigger>
-          <TabsTrigger value="master">マスタ登録</TabsTrigger>
-          <TabsTrigger value="list">商品一覧</TabsTrigger>
-          <TabsTrigger value="bulk">一括処理</TabsTrigger>
-          <TabsTrigger value="audit">監査ログ</TabsTrigger>
+          {orderedTabOptions.map((tab) => (
+            <TabsTrigger
+              key={tab.value}
+              value={tab.value}
+              draggable={isAuthenticated}
+              onDragStart={() => isAuthenticated && setDraggingTab(tab.value)}
+              onDragEnd={() => setDraggingTab(null)}
+              onDragOver={(event) => {
+                if (!isAuthenticated || !draggingTab) return
+                event.preventDefault()
+              }}
+              onDrop={(event) => {
+                if (!isAuthenticated || !draggingTab) return
+                event.preventDefault()
+                handleTabDrop(tab.value)
+              }}
+            >
+              {tab.label}
+            </TabsTrigger>
+          ))}
         </TabsList>
 
         <TabsContent value="cost" className="space-y-6">
@@ -1003,17 +1118,14 @@ export default function Home() {
         </TabsContent>
 
         <TabsContent value="stock" className="space-y-6">
-          <StockTab
+          <StockListTab
             data={data}
-            products={data.products}
-            stocks={stocks}
-            stocksLoaded={stocksLoaded}
             materialStocks={materialStocks}
+            materialStockUnits={materialStockUnits}
+            packagingStocks={packagingStocks}
+            packagingStockUnits={packagingStockUnits}
             masterStocksLoaded={masterStocksLoaded}
             isAuthenticated={isAuthenticated}
-            onAdjust={adjustStock}
-            onSet={setStock}
-            onRefresh={refreshStocks}
           />
         </TabsContent>
 

--- a/src/lib/app-data-sync.ts
+++ b/src/lib/app-data-sync.ts
@@ -1005,6 +1005,10 @@ type ProductListColumnSettingsRow = {
   hidden_columns: string[] | null
 }
 
+type TabOrderSettingsRow = {
+  tab_order: string[] | null
+}
+
 export async function loadProductListColumnSettings(
   userId: string
 ): Promise<{ columnOrder: string[]; hiddenColumns: string[] } | null> {
@@ -1032,6 +1036,37 @@ export async function upsertProductListColumnSettings(
       user_id: userId,
       column_order: columnOrder,
       hidden_columns: hiddenColumns,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "user_id" }
+  )
+  if (error) throw error
+}
+
+export async function loadTabOrderSettings(
+  userId: string
+): Promise<{ tabOrder: string[] } | null> {
+  const { data, error } = await supabaseClient
+    .from("tab_order_settings")
+    .select("tab_order")
+    .eq("user_id", userId)
+    .maybeSingle()
+  if (error) throw error
+  if (!data) return null
+  const row = data as TabOrderSettingsRow
+  return {
+    tabOrder: Array.isArray(row.tab_order) ? row.tab_order : [],
+  }
+}
+
+export async function upsertTabOrderSettings(
+  userId: string,
+  tabOrder: string[]
+): Promise<void> {
+  const { error } = await supabaseClient.from("tab_order_settings").upsert(
+    {
+      user_id: userId,
+      tab_order: tabOrder,
       updated_at: new Date().toISOString(),
     },
     { onConflict: "user_id" }

--- a/supabase/migrations/20260308_tab_order_settings.sql
+++ b/supabase/migrations/20260308_tab_order_settings.sql
@@ -1,0 +1,12 @@
+create table if not exists tab_order_settings (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  tab_order text[] not null default '{}'::text[],
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+alter table tab_order_settings enable row level security;
+
+create policy "tab_order_settings_own" on tab_order_settings
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
## 概要
- 新規「在庫一覧」タブを追加し、材料・梱包材・設備の在庫情報を確認できるようにしました
- タブのドラッグ＆ドロップ並び替えを追加し、ログイン時はSupabaseへ順序を保存するようにしました

## 変更ファイル
- src/app/page.tsx
- src/lib/app-data-sync.ts
- src/app/_components/stock-list/stock-list-tab.tsx（新規）
- supabase/migrations/20260308_tab_order_settings.sql（新規）

## 変更内容
- `StockListTab` を新規作成
  - 材料在庫一覧
  - 梱包材在庫一覧
  - 設備一覧（在庫管理対象外として表示）
- `page.tsx` のタブ描画を配列化し、モバイル/デスクトップとも同じ順序で表示
- タブをドラッグ＆ドロップで並び替え可能に変更（ログイン時のみ有効）
- タブ順序の読込/保存を `tab_order_settings` テーブルで実装
- 未ログイン時はデフォルト順序で表示（保存しない）

## 受け入れ条件確認
- [x] 「在庫一覧」タブが表示される
- [x] 在庫一覧タブで材料・梱包材・設備の在庫が確認できる
- [x] タブをドラッグ＆ドロップで並び替えできる
- [x] タブ順序がSupabaseに保存される（ログイン中）
- [x] 再ログイン後もタブ順序が維持される
- [x] 未ログイン時はデフォルト順序で表示

## 検証
- [x] `npx eslint src/app/page.tsx src/lib/app-data-sync.ts src/app/_components/stock-list/stock-list-tab.tsx`

Closes #140
