### PR TITLE
在庫一覧を登録済みマスタと同列構成にし、在庫数を小数1桁で丸め表示

### DIFF
--- a/src/app/_components/stock-list/stock-list-tab.tsx
+++ b/src/app/_components/stock-list/stock-list-tab.tsx
@@ -2,6 +2,7 @@
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { formatCurrency } from "@/lib/calculations"
 import type { AppData } from "@/lib/types"
 
 type StockListTabProps = {
@@ -14,9 +15,14 @@ type StockListTabProps = {
   isAuthenticated: boolean
 }
 
+const formatRoundedQuantity = (quantity: number) => {
+  const rounded = Math.round((quantity + Number.EPSILON) * 10) / 10
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1)
+}
+
 const formatStock = (quantity: number | undefined, unit: string) => {
   if (quantity === undefined) return "未設定"
-  return `${quantity} ${unit}`.trim()
+  return `${formatRoundedQuantity(quantity)} ${unit}`.trim()
 }
 
 export function StockListTab({
@@ -31,15 +37,28 @@ export function StockListTab({
   const materialRows = data.materials.map((material) => ({
     id: material.id,
     name: material.name,
+    unit: material.unit,
+    unitCost: material.unitCost,
+    currency: material.currency,
+    unitsPerBatch: material.unitsPerBatch ?? 1,
+    usePercentageMode: material.usePercentageMode ?? false,
+    supplier: material.supplier,
+    note: material.note,
     stock: materialStocks.get(material.id),
-    unit: materialStockUnits.get(material.id)?.trim() || material.unit,
+    stockUnit: materialStockUnits.get(material.id)?.trim() || material.unit,
   }))
 
   const packagingRows = data.packagingItems.map((item) => ({
     id: item.id,
     name: item.name,
+    unit: item.unit,
+    unitCost: item.unitCost,
+    currency: item.currency,
+    unitsPerBatch: item.unitsPerBatch ?? 1,
+    sizeDescription: item.sizeDescription,
+    note: item.note,
     stock: packagingStocks.get(item.id),
-    unit: packagingStockUnits.get(item.id)?.trim() || item.unit,
+    stockUnit: packagingStockUnits.get(item.id)?.trim() || item.unit,
   }))
 
   return (
@@ -64,18 +83,30 @@ export function StockListTab({
             <p className="text-sm text-muted-foreground">材料が登録されていません。</p>
           ) : (
             <div className="overflow-x-auto">
-              <Table>
+              <Table className="min-w-[980px]">
                 <TableHeader>
                   <TableRow>
                     <TableHead>名称</TableHead>
+                    <TableHead>単位</TableHead>
+                    <TableHead>単価</TableHead>
+                    <TableHead>セット数</TableHead>
+                    <TableHead>入力モード</TableHead>
+                    <TableHead>仕入先</TableHead>
+                    <TableHead>備考</TableHead>
                     <TableHead className="text-right">現在残数</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {materialRows.map((row) => (
                     <TableRow key={row.id}>
-                      <TableCell>{row.name}</TableCell>
-                      <TableCell className="text-right">{formatStock(row.stock, row.unit)}</TableCell>
+                      <TableCell className="font-medium">{row.name}</TableCell>
+                      <TableCell>{row.unit}</TableCell>
+                      <TableCell>{formatCurrency(row.unitCost, row.currency)}</TableCell>
+                      <TableCell>{`${row.unitsPerBatch}単位/セット`}</TableCell>
+                      <TableCell>{row.usePercentageMode ? "比率入力 (%)" : "数量入力"}</TableCell>
+                      <TableCell>{row.supplier || "-"}</TableCell>
+                      <TableCell>{row.note || "-"}</TableCell>
+                      <TableCell className="text-right">{formatStock(row.stock, row.stockUnit)}</TableCell>
                     </TableRow>
                   ))}
                 </TableBody>
@@ -98,18 +129,28 @@ export function StockListTab({
             <p className="text-sm text-muted-foreground">梱包材が登録されていません。</p>
           ) : (
             <div className="overflow-x-auto">
-              <Table>
+              <Table className="min-w-[980px]">
                 <TableHeader>
                   <TableRow>
                     <TableHead>名称</TableHead>
+                    <TableHead>単位</TableHead>
+                    <TableHead>単価</TableHead>
+                    <TableHead>セット数</TableHead>
+                    <TableHead>仕様</TableHead>
+                    <TableHead>備考</TableHead>
                     <TableHead className="text-right">現在残数</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {packagingRows.map((row) => (
                     <TableRow key={row.id}>
-                      <TableCell>{row.name}</TableCell>
-                      <TableCell className="text-right">{formatStock(row.stock, row.unit)}</TableCell>
+                      <TableCell className="font-medium">{row.name}</TableCell>
+                      <TableCell>{row.unit}</TableCell>
+                      <TableCell>{formatCurrency(row.unitCost, row.currency)}</TableCell>
+                      <TableCell>{`${row.unitsPerBatch}単位/セット`}</TableCell>
+                      <TableCell>{row.sizeDescription || "-"}</TableCell>
+                      <TableCell>{row.note || "-"}</TableCell>
+                      <TableCell className="text-right">{formatStock(row.stock, row.stockUnit)}</TableCell>
                     </TableRow>
                   ))}
                 </TableBody>
@@ -128,18 +169,24 @@ export function StockListTab({
             <p className="text-sm text-muted-foreground">設備が登録されていません。</p>
           ) : (
             <div className="overflow-x-auto">
-              <Table>
+              <Table className="min-w-[720px]">
                 <TableHeader>
                   <TableRow>
-                    <TableHead>設備名</TableHead>
-                    <TableHead className="text-right">設備在庫</TableHead>
+                    <TableHead>名称</TableHead>
+                    <TableHead>取得額</TableHead>
+                    <TableHead>償却年数</TableHead>
+                    <TableHead>使用率</TableHead>
+                    <TableHead>備考</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {data.equipments.map((equipment) => (
                     <TableRow key={equipment.id}>
-                      <TableCell>{equipment.name}</TableCell>
-                      <TableCell className="text-right">在庫管理対象外</TableCell>
+                      <TableCell className="font-medium">{equipment.name}</TableCell>
+                      <TableCell>{formatCurrency(equipment.acquisitionCost, equipment.currency)}</TableCell>
+                      <TableCell>{`${equipment.amortizationYears}年`}</TableCell>
+                      <TableCell>{`${equipment.utilizationRate ?? 100}%`}</TableCell>
+                      <TableCell>{equipment.note || "-"}</TableCell>
                     </TableRow>
                   ))}
                 </TableBody>


### PR DESCRIPTION
## 対応内容
- 在庫一覧（材料）を登録済みマスタと同じ列構成に拡張
- 在庫一覧（梱包材）を登録済みマスタと同じ列構成に拡張
- 設備一覧も登録済みマスタの主要列（名称/取得額/償却年数/使用率/備考）で表示
- 在庫数表示を小数1桁四捨五入に統一（例: 0.89999 -> 0.9）

## 変更ファイル
- src/app/_components/stock-list/stock-list-tab.tsx

## 補足
- この環境では eslint が未インストールのため lint 実行は未実施です。