### PR TITLE
Issue #151: 商品一覧タブと在庫タブを統合

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,8 +47,7 @@ const tabOptions = [
   { value: "analytics", label: "集計データ" },
   { value: "product", label: "商品登録" },
   { value: "master", label: "マスタ登録" },
-  { value: "list", label: "商品一覧" },
-  { value: "stock", label: "在庫一覧" },
+  { value: "list", label: "商品/在庫一覧" },
   { value: "bulk", label: "一括処理" },
   { value: "audit", label: "監査ログ" },
 ] as const
@@ -1115,9 +1114,7 @@ export default function Home() {
               )}
             </CardContent>
           </Card>
-        </TabsContent>
 
-        <TabsContent value="stock" className="space-y-6">
           <StockListTab
             data={data}
             materialStocks={materialStocks}


### PR DESCRIPTION
## Summary
- 「商品一覧」タブと「在庫」タブを「商品/在庫一覧」タブに統合
- 材料残数シミュレーション機能を商品/在庫一覧タブに移動
- 不要になったstock-tab.tsxを削除

## 変更内容
- `tabOptions`から`stock`タブを削除し、`list`タブの名称を「商品/在庫一覧」に変更
- `MaterialStockSimulator`コンポーネントを商品/在庫一覧タブに追加
- `StockTab`コンポーネントのインポートを削除
- `src/app/_components/stock/stock-tab.tsx`を削除

## Test plan
- [ ] 商品/在庫一覧タブが表示される
- [ ] 登録済み商品セクションが正常に動作する（在庫増減操作）
- [ ] 商品一覧テーブルが正常に動作する（検索、フィルタ、ソート）
- [ ] 材料残数シミュレーションが正常に動作する
- [ ] 在庫タブが削除されている

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)