### PR TITLE
#153 原価サマリ/登録済みマスタの開閉状態をリロード後も保持

### DIFF
--- a/src/app/_components/cost/cost-tab.tsx
+++ b/src/app/_components/cost/cost-tab.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import type { AppData } from "@/lib/types"
@@ -33,8 +33,34 @@ const defaultOpenState: Record<CostSectionKey, boolean> = {
   logisticsElectricity: true,
 }
 
+const COST_TAB_OPEN_STATE_STORAGE_KEY = "cost-app-cost-tab-open-state"
+
+const loadCostTabOpenState = (): Record<CostSectionKey, boolean> => {
+  if (typeof window === "undefined") return defaultOpenState
+  try {
+    const raw = window.localStorage.getItem(COST_TAB_OPEN_STATE_STORAGE_KEY)
+    if (!raw) return defaultOpenState
+    const parsed = JSON.parse(raw) as Partial<Record<CostSectionKey, unknown>>
+    return {
+      summary: typeof parsed.summary === "boolean" ? parsed.summary : defaultOpenState.summary,
+      profitSimulation: typeof parsed.profitSimulation === "boolean" ? parsed.profitSimulation : defaultOpenState.profitSimulation,
+      packaging: typeof parsed.packaging === "boolean" ? parsed.packaging : defaultOpenState.packaging,
+      laborOutsourcing: typeof parsed.laborOutsourcing === "boolean" ? parsed.laborOutsourcing : defaultOpenState.laborOutsourcing,
+      developmentEquipment: typeof parsed.developmentEquipment === "boolean" ? parsed.developmentEquipment : defaultOpenState.developmentEquipment,
+      logisticsElectricity: typeof parsed.logisticsElectricity === "boolean" ? parsed.logisticsElectricity : defaultOpenState.logisticsElectricity,
+    }
+  } catch {
+    return defaultOpenState
+  }
+}
+
 export function CostTab({ data }: CostTabProps) {
-  const [openState, setOpenState] = useState<Record<CostSectionKey, boolean>>(defaultOpenState)
+  const [openState, setOpenState] = useState<Record<CostSectionKey, boolean>>(() => loadCostTabOpenState())
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    window.localStorage.setItem(COST_TAB_OPEN_STATE_STORAGE_KEY, JSON.stringify(openState))
+  }, [openState])
 
   const setAllOpenState = (value: boolean) => {
     setOpenState({

--- a/src/app/_components/master/list/master-list-view.tsx
+++ b/src/app/_components/master/list/master-list-view.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import type { AppActions } from "@/lib/app-data"
@@ -52,8 +52,36 @@ const defaultOpenState: Record<MasterListSectionKey, boolean> = {
   equipment: true,
 }
 
+const MASTER_LIST_OPEN_STATE_STORAGE_KEY = "cost-app-master-list-open-state"
+
+const loadMasterListOpenState = (): Record<MasterListSectionKey, boolean> => {
+  if (typeof window === "undefined") return defaultOpenState
+  try {
+    const raw = window.localStorage.getItem(MASTER_LIST_OPEN_STATE_STORAGE_KEY)
+    if (!raw) return defaultOpenState
+    const parsed = JSON.parse(raw) as Partial<Record<MasterListSectionKey, unknown>>
+    return {
+      category: typeof parsed.category === "boolean" ? parsed.category : defaultOpenState.category,
+      material: typeof parsed.material === "boolean" ? parsed.material : defaultOpenState.material,
+      packaging: typeof parsed.packaging === "boolean" ? parsed.packaging : defaultOpenState.packaging,
+      optionPreset: typeof parsed.optionPreset === "boolean" ? parsed.optionPreset : defaultOpenState.optionPreset,
+      shipping: typeof parsed.shipping === "boolean" ? parsed.shipping : defaultOpenState.shipping,
+      fee: typeof parsed.fee === "boolean" ? parsed.fee : defaultOpenState.fee,
+      labor: typeof parsed.labor === "boolean" ? parsed.labor : defaultOpenState.labor,
+      equipment: typeof parsed.equipment === "boolean" ? parsed.equipment : defaultOpenState.equipment,
+    }
+  } catch {
+    return defaultOpenState
+  }
+}
+
 export function MasterListView({ data, actions, isAuthenticated, materialStocks, materialStockUnits, packagingStocks, packagingStockUnits, masterStocksLoaded, onSetMaterialStock, onSetPackagingStock, onAdjustMaterialStock, onAdjustPackagingStock }: MasterListViewProps) {
-  const [openState, setOpenState] = useState<Record<MasterListSectionKey, boolean>>(defaultOpenState)
+  const [openState, setOpenState] = useState<Record<MasterListSectionKey, boolean>>(() => loadMasterListOpenState())
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    window.localStorage.setItem(MASTER_LIST_OPEN_STATE_STORAGE_KEY, JSON.stringify(openState))
+  }, [openState])
 
   const setAllOpenState = (value: boolean) => {
     setOpenState({


### PR DESCRIPTION
## 概要
- 原価サマリタブの各セクション開閉状態を localStorage に保存し、リロード後も復元するようにしました
- 登録済みマスタ（一覧ビュー）の各セクション開閉状態も同様に保存・復元するようにしました
- 「全て開く」「全て閉じる」操作後の状態も保存されます

## 変更ファイル
- `src/app/_components/cost/cost-tab.tsx`
- `src/app/_components/master/list/master-list-view.tsx`

## 受け入れ条件
- [x] 原価サマリのセクションを開閉後、リロードしても状態が維持される
- [x] 登録済みマスタのセクションを開閉後、リロードしても状態が維持される
- [x] 「全て開く」「全て閉じる」後も状態が保持される

Closes #153
