### PR TITLE
#164 コンテンツエリアの横幅拡張・レイアウト改善

### DIFF
--- a/src/app/_components/audit/audit-tab.tsx
+++ b/src/app/_components/audit/audit-tab.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import type { AuditFilters, AuditLog, ChangeSummary } from "@/lib/types"
@@ -128,12 +127,12 @@ export function AuditTab({ logs, loading, onRefresh, onLoadMore, hasMore, filter
 
   return (
     <div className="space-y-4">
-      <Card>
-        <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <CardTitle>保存操作の監査ログ</CardTitle>
-            <CardDescription>直近 {logs.length} 件の保存履歴を表示します。</CardDescription>
-          </div>
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-xl font-semibold">保存操作の監査ログ</h2>
+          <p className="text-sm text-muted-foreground">直近 {logs.length} 件の保存履歴を表示します。</p>
+        </div>
+        <div className="space-y-4 rounded-lg border p-4">
           <div className="flex flex-wrap items-end gap-3">
             <div className="space-y-1">
               <p className="text-xs text-muted-foreground">開始日</p>
@@ -154,25 +153,23 @@ export function AuditTab({ logs, loading, onRefresh, onLoadMore, hasMore, filter
             <Button type="button" variant="ghost" size="sm" onClick={() => onFiltersChange({})}>
               フィルター解除
             </Button>
+            <div className="ml-auto flex flex-wrap gap-2">
+              <Button type="button" size="sm" variant="outline" onClick={onRefresh} disabled={loading}>
+                {loading ? "読込中" : "最新を取得"}
+              </Button>
+              <Button type="button" size="sm" variant="secondary" onClick={onLoadMore} disabled={loading || !hasMore}>
+                {hasMore ? "さらに読み込む" : "末尾まで表示"}
+              </Button>
+              <Button type="button" size="sm" variant="ghost" onClick={handleExportCsv}>
+                CSVエクスポート
+              </Button>
+            </div>
           </div>
-          <div className="flex flex-wrap gap-2">
-            <Button type="button" size="sm" variant="outline" onClick={onRefresh} disabled={loading}>
-              {loading ? "読込中" : "最新を取得"}
-            </Button>
-            <Button type="button" size="sm" variant="secondary" onClick={onLoadMore} disabled={loading || !hasMore}>
-              {hasMore ? "さらに読み込む" : "末尾まで表示"}
-            </Button>
-            <Button type="button" size="sm" variant="ghost" onClick={handleExportCsv}>
-              CSVエクスポート
-            </Button>
-          </div>
-        </CardHeader>
-        <CardContent>
           {logs.length === 0 ? (
             <p className="text-sm text-muted-foreground">まだ監査ログがありません。</p>
           ) : (
-            <div className="max-h-[520px] overflow-auto">
-              <Table>
+            <div className="max-h-[520px] w-full overflow-auto">
+              <Table className="w-full min-w-[840px]">
                 <TableHeader>
                   <TableRow>
                     <TableHead>記録概要</TableHead>
@@ -199,8 +196,8 @@ export function AuditTab({ logs, loading, onRefresh, onLoadMore, hasMore, filter
               </Table>
             </div>
           )}
-        </CardContent>
-      </Card>
+        </div>
+      </section>
     </div>
   )
 }

--- a/src/app/_components/product-list/customizable-product-table.tsx
+++ b/src/app/_components/product-list/customizable-product-table.tsx
@@ -338,7 +338,7 @@ export function CustomizableProductTable({
           </TableHeader>
           <TableBody>
             {entries.map((entry) => (
-              <TableRow key={entry.product.id}>
+              <TableRow key={entry.product.id} className="group">
                 <TableCell className="font-medium">{entry.product.name}</TableCell>
                 {visibleColumns.map((key) => (
                   <TableCell
@@ -357,7 +357,7 @@ export function CustomizableProductTable({
                   </TableCell>
                 ))}
                 <TableCell className="w-48 text-right">
-                  <div className="flex flex-wrap justify-end gap-2">
+                  <div className="flex flex-wrap justify-end gap-2 md:opacity-0 md:transition-opacity md:group-hover:opacity-100 md:group-focus-within:opacity-100">
                     <Button
                       type="button"
                       size="sm"

--- a/src/app/_components/shared/ui.tsx
+++ b/src/app/_components/shared/ui.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react"
 
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 
@@ -201,17 +200,17 @@ export function CostDisplay({
   }
 
   return (
-    <Card className="overflow-x-hidden">
-      <CardHeader>
-        <CardTitle>{title}</CardTitle>
-        <CardDescription>{description}</CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-3">
+    <section className="space-y-3 rounded-lg border p-4">
+      <div>
+        <h2 className="text-xl font-semibold">{title}</h2>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+      <div className="space-y-3">
         <Input
           value={productFilter}
           onChange={(event) => setProductFilter(event.target.value)}
           placeholder="商品名で絞り込み"
-          className="md:max-w-xs"
+          className="w-full md:w-72"
         />
         <p className="text-xs text-muted-foreground">
           並び順: {sortLabelMap[sortKey]}（{sortDirection === "asc" ? "昇順" : "降順"}）
@@ -255,7 +254,7 @@ export function CostDisplay({
             </Table>
           </div>
         )}
-      </CardContent>
-    </Card>
+      </div>
+    </section>
   )
 }

--- a/src/app/dashboard-page.tsx
+++ b/src/app/dashboard-page.tsx
@@ -647,8 +647,16 @@ export default function DashboardPage({ routeTab }: { routeTab: TabValue }) {
     return renderLoading()
   }
 
-  // listタブは全幅、他のタブはmax-w-6xl
-  const mainMaxWidth = activeTab === "list" ? "max-w-full" : "max-w-6xl"
+  const tabContentWidthMap: Record<TabValue, string> = {
+    cost: "max-w-6xl",
+    analytics: "max-w-6xl",
+    product: "max-w-4xl",
+    master: "max-w-5xl",
+    list: "max-w-full",
+    bulk: "max-w-4xl",
+    audit: "max-w-full",
+  }
+  const mainMaxWidth = tabContentWidthMap[activeTab]
   const sidebarWidthClass = sidebarCollapsed ? "w-[76px]" : "w-[260px]"
 
   return (
@@ -989,14 +997,14 @@ export default function DashboardPage({ routeTab }: { routeTab: TabValue }) {
         </TabsContent>
 
         <TabsContent value="list" className="space-y-6">
-          <Card>
-            <CardHeader className="space-y-4">
+          <section className="space-y-4">
+            <div>
+              <h2 className="text-xl font-semibold">商品一覧</h2>
+              <p className="text-sm text-muted-foreground">登録済み商品のカテゴリ・オプション・備考を確認</p>
+              <p className="text-xs text-muted-foreground">該当 {filteredProductEntries.length} 件</p>
+            </div>
+            <div className="space-y-3 rounded-lg border p-4">
               <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-                <div>
-                  <CardTitle>商品一覧</CardTitle>
-                  <CardDescription>登録済み商品のカテゴリ・オプション・備考を確認</CardDescription>
-                  <p className="text-xs text-muted-foreground">該当 {filteredProductEntries.length} 件</p>
-                </div>
                 <div className="flex flex-wrap gap-2">
                   <Button type="button" size="sm" onClick={handleCreateProduct}>
                     <Plus className="mr-1.5 h-4 w-4" />
@@ -1021,10 +1029,7 @@ export default function DashboardPage({ routeTab }: { routeTab: TabValue }) {
                   placeholder="商品名・備考・設備で検索"
                   className="w-full flex-1 min-w-[220px]"
                 />
-                <Select
-                  value={productCategoryLargeFilter ?? "all"}
-                  onValueChange={handleCategoryLargeFilterChange}
-                >
+                <Select value={productCategoryLargeFilter ?? "all"} onValueChange={handleCategoryLargeFilterChange}>
                   <SelectTrigger className="w-full md:w-48">
                     <SelectValue placeholder="大カテゴリで絞り込み" />
                   </SelectTrigger>
@@ -1037,10 +1042,7 @@ export default function DashboardPage({ routeTab }: { routeTab: TabValue }) {
                     ))}
                   </SelectContent>
                 </Select>
-                <Select
-                  value={productCategoryMediumFilter ?? "all"}
-                  onValueChange={handleCategoryMediumFilterChange}
-                >
+                <Select value={productCategoryMediumFilter ?? "all"} onValueChange={handleCategoryMediumFilterChange}>
                   <SelectTrigger className="w-full md:w-48">
                     <SelectValue placeholder="中カテゴリで絞り込み" />
                   </SelectTrigger>
@@ -1053,10 +1055,7 @@ export default function DashboardPage({ routeTab }: { routeTab: TabValue }) {
                     ))}
                   </SelectContent>
                 </Select>
-                <Select
-                  value={productCategorySmallFilter ?? "all"}
-                  onValueChange={handleCategorySmallFilterChange}
-                >
+                <Select value={productCategorySmallFilter ?? "all"} onValueChange={handleCategorySmallFilterChange}>
                   <SelectTrigger className="w-full md:w-48">
                     <SelectValue placeholder="小カテゴリで絞り込み" />
                   </SelectTrigger>
@@ -1085,8 +1084,6 @@ export default function DashboardPage({ routeTab }: { routeTab: TabValue }) {
                   </SelectContent>
                 </Select>
               </div>
-            </CardHeader>
-            <CardContent className="space-y-3">
               {data.products.length === 0 ? (
                 <p className="text-sm text-muted-foreground">まだ商品がありません。</p>
               ) : filteredProductEntries.length === 0 ? (
@@ -1105,8 +1102,8 @@ export default function DashboardPage({ routeTab }: { routeTab: TabValue }) {
                   onDelete={handleDeleteProduct}
                 />
               )}
-            </CardContent>
-          </Card>
+            </div>
+          </section>
 
           <StockListTab
             data={data}


### PR DESCRIPTION
## 対応内容
- タブ別にコンテンツ幅を最適化（issue記載の幅テーブルに合わせて適用）
- `list` タブの商品一覧をカード構成から、見出し + ツールバー + テーブル中心の構成へ変更
- `audit` タブの監査ログをカード構成から、見出し + ツールバー + テーブル中心の構成へ変更
- `CostDisplay`（`src/app/_components/shared/ui.tsx`）をカード依存から `rounded-lg border` ベースに変更
- 商品一覧テーブルの行アクションを、デスクトップで行ホバー時に表示（モバイルは常時表示）

## 確認項目
- [x] 行ホバーでアクションボタンが表示される
- [x] 検索・フィルターをツールバー配置に変更
- [x] セクションごとの幅最適化を適用
- [x] list / audit で横幅を拡張し、横スクロールを軽減
- [x] 既存機能（検索・絞り込み・CSV・在庫増減）を維持

## 動作確認
- `npx eslint src/app/dashboard-page.tsx src/app/_components/audit/audit-tab.tsx src/app/_components/shared/ui.tsx src/app/_components/product-list/customizable-product-table.tsx`
  - 変更ファイルでエラーなし
- `npm run lint`
  - 既存ファイル由来のエラーで失敗（今回差分外）
