### PR TITLE
本番で/ui-prototype/costへ遷移してしまう問題を修正

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from "next/server"
 
 export function middleware(request: NextRequest) {
   if (request.nextUrl.pathname === "/") {
-    return NextResponse.redirect(new URL("/ui-prototype/cost", request.url))
+    return NextResponse.redirect(new URL("/cost", request.url))
   }
   return NextResponse.next()
 }


### PR DESCRIPTION
## 概要
本番環境で `/` アクセス時に `ui-prototype/cost` へリダイレクトされる問題を修正しました。

## 原因
`src/middleware.ts` のルート判定で、遷移先が `/ui-prototype/cost` のまま残っていました。

## 対応
- `src/middleware.ts`
  - `NextResponse.redirect(new URL("/ui-prototype/cost", request.url))`
  - → `NextResponse.redirect(new URL("/cost", request.url))`

## 確認
- `npx eslint src/middleware.ts` でエラーなし
- 変更は1ファイルのみ
