### PR TITLE
左メニューの固定表示（スクロール追従）

### DIFF
--- a/src/app/dashboard-page.tsx
+++ b/src/app/dashboard-page.tsx
@@ -663,7 +663,7 @@ export default function DashboardPage({ routeTab }: { routeTab: TabValue }) {
     <div className="min-h-screen bg-background">
       <div className="flex min-h-screen">
         {/* サイドバー */}
-        <aside className={`hidden border-r bg-card p-3 md:flex md:flex-col ${sidebarWidthClass}`}>
+        <aside className={`hidden sticky top-0 h-screen overflow-y-auto border-r bg-card p-3 md:flex md:flex-col ${sidebarWidthClass}`}>
           <div className="mb-3 flex items-center justify-between gap-2 px-1">
             {!sidebarCollapsed && <p className="text-sm font-semibold">Cost App</p>}
             <Button type="button" variant="ghost" size="sm" onClick={() => setSidebarCollapsed((prev) => !prev)}>


### PR DESCRIPTION
## Summary
- サイドバーに `sticky top-0 h-screen overflow-y-auto` を適用
- コンテンツスクロール時もメニュー・ログアウトボタンが常に表示される
- モバイルドロワーメニューには影響なし

Closes #175

## Test plan
- [ ] サイドバーがスクロールしても画面左に固定されている
- [ ] ログアウトボタンが常に表示される
- [ ] サイドバー内の項目が多い場合、サイドバー内でスクロールできる
- [ ] モバイルドロワーメニューに影響がない

https://claude.ai/code/session_011NSQ3dT5KEytd8KEwmQEp7