### PR TITLE
mainタグにoverflow-x-hidden追加でページ全体の横スクロール防止

### DIFF
--- a/src/app/dashboard-page.tsx
+++ b/src/app/dashboard-page.tsx
@@ -793,7 +793,7 @@ export default function DashboardPage({ routeTab }: { routeTab: TabValue }) {
             </div>
           </header>
 
-          <main className={`flex-1 p-4 md:p-6 ${mainMaxWidth}`}>
+          <main className={`flex-1 overflow-x-hidden p-4 md:p-6 ${mainMaxWidth}`}>
             {/* ログインパネル */}
             {loginPanelOpen && authState.status !== "authenticated" && (
               <Card className="mb-6 border-primary/50 bg-background/95 shadow-lg">


### PR DESCRIPTION
## Summary
- `<main>`タグに`overflow-x-hidden`クラスを追加
- スマホ表示時のページ全体の横スクロールを防止
- テーブルはラッパー内で引き続き横スクロール可能

Closes #184

## Test plan
- [ ] 375px幅のスマホ表示でページ全体の横スクロールが発生しない
- [ ] テーブルはラッパー内で横スクロール可能なまま
- [ ] デスクトップ表示への影響なし
- [ ] ダイアログ・ドロップダウンが切れないこと

https://claude.ai/code/session_011NSQ3dT5KEytd8KEwmQEp7