### PR TITLE
原価サマリ: カードごと横スクロールされる問題を修正

### DIFF
--- a/src/app/_components/cost/cost-tab.tsx
+++ b/src/app/_components/cost/cost-tab.tsx
@@ -118,32 +118,32 @@ export function CostTab({ data }: CostTabProps) {
         </div>
       </div>
 
-      <div className="cost-section-block space-y-3">
+      <div className="cost-section-block space-y-3 overflow-hidden">
         {renderSectionToggle("summary", "原価サマリ")}
         {openState.summary && <CostSummarySection data={data} />}
       </div>
 
-      <div className="cost-section-block space-y-3">
+      <div className="cost-section-block space-y-3 overflow-hidden">
         {renderSectionToggle("profitSimulation", "利益シミュレーション")}
         {openState.profitSimulation && <ProfitSimulationSection data={data} />}
       </div>
 
-      <div className="cost-section-block space-y-3">
+      <div className="cost-section-block space-y-3 overflow-hidden">
         {renderSectionToggle("packaging", "梱包コスト集計")}
         {openState.packaging && <PackagingCostSection data={data} />}
       </div>
 
-      <div className="cost-section-block space-y-3">
+      <div className="cost-section-block space-y-3 overflow-hidden">
         {renderSectionToggle("laborOutsourcing", "人件費・外注費集計")}
         {openState.laborOutsourcing && <LaborOutsourcingSection data={data} />}
       </div>
 
-      <div className="cost-section-block space-y-3">
+      <div className="cost-section-block space-y-3 overflow-hidden">
         {renderSectionToggle("developmentEquipment", "開発・設備コスト")}
         {openState.developmentEquipment && <DevelopmentEquipmentSection data={data} />}
       </div>
 
-      <div className="cost-section-block space-y-3">
+      <div className="cost-section-block space-y-3 overflow-hidden">
         {renderSectionToggle("logisticsElectricity", "物流・電力コスト")}
         {openState.logisticsElectricity && <LogisticsElectricitySection data={data} />}
       </div>

--- a/src/app/_components/cost/sections/cost-summary-section.tsx
+++ b/src/app/_components/cost/sections/cost-summary-section.tsx
@@ -101,7 +101,7 @@ export function CostSummarySection({ data }: CostSummarySectionProps) {
             {data.products.length === 0 ? "まだ原価計算対象の商品がありません。" : "条件に一致する商品がありません。"}
           </p>
         ) : (
-          <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain">
+          <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
             <Table className="cost-summary-table w-auto min-w-max">
               <TableHeader>
                 <TableRow className="bg-muted/50 hover:bg-muted/50">


### PR DESCRIPTION
## Summary
- `cost-section-block`全6セクションに`overflow-hidden`追加でカードの横はみ出し防止
- `cost-summary-section`のテーブルラッパーに`touch-pan-x`追加でスムーズなタッチスクロール対応
- 前提条件の#184（mainタグのoverflow-x-hidden）は適用済み

Closes #185

## Test plan
- [ ] 375px幅のスマホ表示でカードが画面幅に収まる
- [ ] テーブル部分のみ横スクロール可能
- [ ] touch-pan-xによるスムーズなタッチスクロール
- [ ] デスクトップ表示への影響なし
- [ ] 全6セクション確認: 原価サマリ、利益シミュレーション、梱包コスト、人件費・外注費、開発・設備、物流・電力

https://claude.ai/code/session_011NSQ3dT5KEytd8KEwmQEp7