### PR TITLE
feat: Claude Code Reviewワークフローを追加

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,37 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          prompt: |
+            このPull Requestの差分をレビューしてください。以下の観点で確認し、問題があれば具体的な改善案と共にレビューコメントを投稿してください:
+            1. TypeScriptの型安全性
+            2. React/Next.jsのベストプラクティス
+            3. コード品質・パフォーマンス
+            4. セキュリティ上の問題（特にAPIルート）
+            5. バグの可能性
+            問題が見つからなくても、レビュー完了のコメントを必ず投稿してください。


### PR DESCRIPTION
## Summary
- Claude Code Reviewワークフローを新規追加
- `track_progress: true` でtag modeを強制し、PRコメント投稿を確実にする
- `pull_request`, `issue_comment`, `pull_request_review_comment` トリガーに対応

## 背景
PR #193でワークフローを追加していたが、ワークフローファイル自体がPRに含まれる場合 `WorkflowValidationSkipError` でスキップされるため、先にmainにマージする必要がある

https://claude.ai/code/session_011NSQ3dT5KEytd8KEwmQEp7