### PR TITLE
fix: スマホでカードが横スクロールする問題を修正

### DIFF
--- a/src/app/_components/audit/audit-tab.tsx
+++ b/src/app/_components/audit/audit-tab.tsx
@@ -179,7 +179,7 @@ export function AuditTab({ logs, loading, onRefresh, onLoadMore, hasMore, filter
       {logs.length === 0 ? (
         <p className="text-sm text-muted-foreground">まだ監査ログがありません。</p>
       ) : (
-        <div className="max-h-[600px] w-full overflow-auto overscroll-x-contain touch-pan-x rounded-lg border">
+        <div className="max-h-[600px] w-full min-w-0 max-w-full overflow-auto overscroll-x-contain touch-pan-x rounded-lg border">
           <Table className="w-full min-w-[840px]">
             <TableHeader>
               <TableRow className="bg-muted/50 hover:bg-muted/50">

--- a/src/app/_components/cost/sections/cost-summary-section.tsx
+++ b/src/app/_components/cost/sections/cost-summary-section.tsx
@@ -101,7 +101,7 @@ export function CostSummarySection({ data }: CostSummarySectionProps) {
             {data.products.length === 0 ? "まだ原価計算対象の商品がありません。" : "条件に一致する商品がありません。"}
           </p>
         ) : (
-          <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
+          <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
             <Table className="cost-summary-table w-auto min-w-max">
               <TableHeader>
                 <TableRow className="bg-muted/50 hover:bg-muted/50">

--- a/src/app/_components/cost/sections/equipment-allocation-section.tsx
+++ b/src/app/_components/cost/sections/equipment-allocation-section.tsx
@@ -67,7 +67,7 @@ export function EquipmentAllocationSection({ data }: CostSectionProps) {
         {equipmentUsageGroups.length === 0 ? (
           <p className="text-sm text-muted-foreground">まだ設備配賦が登録されていません。</p>
         ) : (
-          <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
+          <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
             <Table className="w-auto min-w-max">
               <TableHeader>
                 <TableRow>

--- a/src/app/_components/cost/sections/packaging-cost-section.tsx
+++ b/src/app/_components/cost/sections/packaging-cost-section.tsx
@@ -213,7 +213,7 @@ export function PackagingCostSection({ data }: PackagingCostSectionProps) {
           {rows.length === 0 ? (
             <p className="text-sm text-muted-foreground">条件に一致するデータがありません。</p>
           ) : (
-            <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
+            <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
               <Table className="w-auto min-w-max">
                 <TableHeader>
                   <TableRow>
@@ -288,7 +288,7 @@ export function PackagingCostSection({ data }: PackagingCostSectionProps) {
           {summaryRows.length === 0 ? (
             <p className="text-sm text-muted-foreground">条件に一致するデータがありません。</p>
           ) : (
-            <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
+            <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
               <Table className="w-auto min-w-max">
                 <TableHeader>
                   <TableRow>

--- a/src/app/_components/master/register/master-overview-section.tsx
+++ b/src/app/_components/master/register/master-overview-section.tsx
@@ -252,7 +252,7 @@ export function MasterOverviewSection({ data }: MasterOverviewSectionProps) {
         {masterOverviewRows.length === 0 ? (
           <p className="text-sm text-muted-foreground">条件に一致するマスタはありません。</p>
         ) : (
-          <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
+          <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
             <Table className="w-auto min-w-max">
               <TableHeader>
                 <TableRow>

--- a/src/app/_components/master/sections/category/category-list-section.tsx
+++ b/src/app/_components/master/sections/category/category-list-section.tsx
@@ -283,7 +283,7 @@ export function CategoryListSection({ data, actions, createTempId }: CategoryLis
           {data.categories.large.length === 0 ? (
             <p className="text-sm text-muted-foreground">まだ登録がありません。</p>
           ) : (
-            <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
+            <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
               <Table className="min-w-[640px]">
                 <TableHeader>
                   <TableRow>
@@ -354,7 +354,7 @@ export function CategoryListSection({ data, actions, createTempId }: CategoryLis
           {data.categories.medium.length === 0 ? (
             <p className="text-sm text-muted-foreground">まだ登録がありません。</p>
           ) : (
-            <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
+            <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
               <Table className="min-w-[700px]">
                 <TableHeader>
                   <TableRow>
@@ -453,7 +453,7 @@ export function CategoryListSection({ data, actions, createTempId }: CategoryLis
           {data.categories.small.length === 0 ? (
             <p className="text-sm text-muted-foreground">まだ登録がありません。</p>
           ) : (
-            <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
+            <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
               <Table className="min-w-[720px]">
                 <TableHeader>
                   <TableRow>

--- a/src/app/_components/master/sections/equipment/equipment-list-section.tsx
+++ b/src/app/_components/master/sections/equipment/equipment-list-section.tsx
@@ -115,7 +115,7 @@ export function EquipmentListSection({ data, actions, createTempId }: EquipmentL
         {data.equipments.length === 0 ? (
           <p className="text-sm text-muted-foreground">まだ登録がありません。</p>
         ) : (
-          <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
+          <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
             <Table className="min-w-[640px]">
               <TableHeader>
                 <TableRow>

--- a/src/app/_components/master/sections/fee/fee-list-section.tsx
+++ b/src/app/_components/master/sections/fee/fee-list-section.tsx
@@ -102,7 +102,7 @@ export function FeeListSection({ data, actions, createTempId }: FeeListSectionPr
         {data.fees.length === 0 ? (
           <p className="text-sm text-muted-foreground">まだ登録がありません。</p>
         ) : (
-          <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
+          <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
             <Table className="min-w-[640px]">
               <TableHeader>
                 <TableRow>

--- a/src/app/_components/master/sections/labor/labor-list-section.tsx
+++ b/src/app/_components/master/sections/labor/labor-list-section.tsx
@@ -88,7 +88,7 @@ export function LaborListSection({ data, actions, createTempId }: LaborListSecti
         {data.laborRoles.length === 0 ? (
           <p className="text-sm text-muted-foreground">まだ登録がありません。</p>
         ) : (
-          <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
+          <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
             <Table className="min-w-[600px]">
               <TableHeader>
                 <TableRow>

--- a/src/app/_components/master/sections/material/material-list-section.tsx
+++ b/src/app/_components/master/sections/material/material-list-section.tsx
@@ -190,7 +190,7 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
         {data.materials.length === 0 ? (
           <p className="text-sm text-muted-foreground">まだ登録がありません。</p>
         ) : (
-          <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
+          <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
             <Table className="min-w-[980px]">
               <TableHeader>
                 <TableRow>

--- a/src/app/_components/master/sections/option-preset/option-preset-list-section.tsx
+++ b/src/app/_components/master/sections/option-preset/option-preset-list-section.tsx
@@ -102,7 +102,7 @@ export function OptionPresetListSection({ data, actions, createTempId }: OptionP
         {(data.optionPresets ?? []).length === 0 ? (
           <p className="text-sm text-muted-foreground">まだ登録がありません。</p>
         ) : (
-          <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
+          <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
             <Table className="min-w-[640px]">
               <TableHeader>
                 <TableRow>

--- a/src/app/_components/master/sections/packaging/packaging-list-section.tsx
+++ b/src/app/_components/master/sections/packaging/packaging-list-section.tsx
@@ -182,7 +182,7 @@ export function PackagingListSection({ data, actions, createTempId, isAuthentica
         {data.packagingItems.length === 0 ? (
           <p className="text-sm text-muted-foreground">まだ登録がありません。</p>
         ) : (
-          <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
+          <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
             <Table className="min-w-[980px]">
               <TableHeader>
                 <TableRow>

--- a/src/app/_components/master/sections/shipping/shipping-list-section.tsx
+++ b/src/app/_components/master/sections/shipping/shipping-list-section.tsx
@@ -104,7 +104,7 @@ export function ShippingListSection({ data, actions, createTempId }: ShippingLis
         {(data.shippingMethods ?? []).length === 0 ? (
           <p className="text-sm text-muted-foreground">まだ登録がありません。</p>
         ) : (
-          <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
+          <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
             <Table className="min-w-[640px]">
               <TableHeader>
                 <TableRow>

--- a/src/app/_components/product-list/customizable-product-table.tsx
+++ b/src/app/_components/product-list/customizable-product-table.tsx
@@ -308,7 +308,7 @@ export function CustomizableProductTable({
         </div>
       )}
 
-      <div className="overflow-x-auto rounded-lg border">
+      <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x rounded-lg border">
         <Table>
           <TableHeader>
             <TableRow className="bg-muted/50 hover:bg-muted/50">

--- a/src/app/_components/product/sections/registered-products-section.tsx
+++ b/src/app/_components/product/sections/registered-products-section.tsx
@@ -91,7 +91,7 @@ export function RegisteredProductsSection({
         {data.products.length === 0 ? (
           <p className="text-sm text-muted-foreground">まだ商品がありません。</p>
         ) : (
-          <div className="overflow-x-auto overscroll-x-contain touch-pan-x">
+          <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
           <Table className="min-w-[640px]">
             <TableHeader>
               <TableRow>

--- a/src/app/_components/shared/ui.tsx
+++ b/src/app/_components/shared/ui.tsx
@@ -221,7 +221,7 @@ export function CostDisplay({
             {rows.length === 0 ? "まだデータがありません。" : "条件に一致するデータがありません。"}
           </p>
         ) : (
-          <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
+          <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
             <Table className="w-auto min-w-max">
               <TableHeader>
                 <TableRow>

--- a/src/app/_components/stock-list/stock-list-tab.tsx
+++ b/src/app/_components/stock-list/stock-list-tab.tsx
@@ -141,7 +141,7 @@ export function StockListTab({
         ) : materialRows.length === 0 ? (
           <p className="text-sm text-muted-foreground">材料が登録されていません。</p>
         ) : (
-          <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x rounded-lg border">
+          <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x rounded-lg border">
             <Table className="min-w-[980px]">
               <TableHeader>
                 <TableRow className="bg-muted/50 hover:bg-muted/50">
@@ -232,7 +232,7 @@ export function StockListTab({
         ) : packagingRows.length === 0 ? (
           <p className="text-sm text-muted-foreground">梱包材が登録されていません。</p>
         ) : (
-          <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x rounded-lg border">
+          <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x rounded-lg border">
             <Table className="min-w-[980px]">
               <TableHeader>
                 <TableRow className="bg-muted/50 hover:bg-muted/50">
@@ -317,7 +317,7 @@ export function StockListTab({
         {data.equipments.length === 0 ? (
           <p className="text-sm text-muted-foreground">設備が登録されていません。</p>
         ) : (
-          <div className="relative w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x rounded-lg border">
+          <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x rounded-lg border">
             <Table className="min-w-[720px]">
               <TableHeader>
                 <TableRow className="bg-muted/50 hover:bg-muted/50">

--- a/src/app/_components/stock/material-stock-simulator.tsx
+++ b/src/app/_components/stock/material-stock-simulator.tsx
@@ -84,7 +84,7 @@ export function MaterialStockSimulator({ data, materialStocks, masterStocksLoade
         ) : rows.length === 0 ? (
           <p className="text-sm text-muted-foreground">この商品に使用量が設定された材料費明細がありません。</p>
         ) : (
-          <div className="relative w-full overflow-x-auto overscroll-x-contain touch-pan-x">
+          <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
             <Table className="min-w-[640px]">
               <TableHeader>
                 <TableRow>

--- a/src/app/_components/stock/stock-tab.tsx
+++ b/src/app/_components/stock/stock-tab.tsx
@@ -114,7 +114,7 @@ export function StockTab({ data, products, stocks, stocksLoaded, materialStocks,
           ) : products.length === 0 ? (
             <p className="text-sm text-muted-foreground">商品が登録されていません。</p>
           ) : (
-            <div className="overflow-auto">
+            <div className="relative w-full min-w-0 max-w-full overflow-x-auto overscroll-x-contain touch-pan-x">
               <Table>
                 <TableHeader>
                   <TableRow>

--- a/src/app/dashboard-page.tsx
+++ b/src/app/dashboard-page.tsx
@@ -793,7 +793,7 @@ export default function DashboardPage({ routeTab }: { routeTab: TabValue }) {
             </div>
           </header>
 
-          <main className={`flex-1 overflow-x-hidden p-4 md:p-6 ${mainMaxWidth}`}>
+          <main className={`flex-1 min-w-0 overflow-x-hidden p-4 md:p-6 ${mainMaxWidth}`}>
             {/* ログインパネル */}
             {loginPanelOpen && authState.status !== "authenticated" && (
               <Card className="mb-6 border-primary/50 bg-background/95 shadow-lg">

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm min-w-0 overflow-hidden",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- スマホでテーブルを横スクロールすると、カード（Card）も一緒に動いてしまう問題を修正
- 原因: テーブルの `min-w-max` / `min-w-[XXXpx]` が flex 子要素の暗黙的な `min-width: auto` により親コンテナを押し広げていた
- 全テーブルスクロールラッパーに `min-w-0` を追加し、幅の漏れを防止
- `Card` コンポーネントに `min-w-0 overflow-hidden` を追加し、カード自体が広がらないよう保証
- `dashboard-page.tsx` の `<main>` に `min-w-0` を追加

## 変更ファイル (21件)
- `src/components/ui/card.tsx` - Card に min-w-0 overflow-hidden 追加
- `src/app/dashboard-page.tsx` - main に min-w-0 追加
- テーブルスクロールラッパー全19箇所に min-w-0 追加
- 不完全だったラッパー3件を標準パターンに統一

## Test plan
- [ ] スマホ実機またはDevToolsモバイルビューで各ページを確認
- [ ] テーブルを横スクロールしてもカードが動かないことを確認
- [ ] テーブルの横スクロール自体は正常に動作することを確認
- [ ] 対象: 商品一覧、在庫一覧、原価サマリ、登録済みマスタ、監査ログ

https://claude.ai/code/session_011NSQ3dT5KEytd8KEwmQEp7