### PR TITLE
feat: PR作成・コメント時のSlack通知ワークフローを追加

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -1,0 +1,105 @@
+name: Slack Notify
+
+on:
+  pull_request:
+    types: [opened, reopened]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  notify-pr-opened:
+    if: >
+      github.event_name == 'pull_request' &&
+      (github.event.action == 'opened' || github.event.action == 'reopened')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Notify Slack about new PR
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "📝 新しいPRが作成されました",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "📝 新しいPRが作成されました"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*タイトル:*\n<${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*作成者:*\n${{ github.event.pull_request.user.login }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*ブランチ:* `${{ github.event.pull_request.head.ref }}` → `${{ github.event.pull_request.base.ref }}`"
+                  }
+                }
+              ]
+            }
+
+  notify-pr-comment:
+    if: >
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request) ||
+      github.event_name == 'pull_request_review_comment' ||
+      (github.event_name == 'pull_request_review' && github.event.review.body != '')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Notify Slack about PR comment
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "💬 PRにコメントがつきました",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "💬 PRにコメントがつきました"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*PR:*\n<${{ github.event.issue.pull_request.html_url || github.event.pull_request.html_url }}|#${{ github.event.issue.number || github.event.pull_request.number }}>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*コメント者:*\n${{ github.event.comment.user.login || github.event.review.user.login }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*コメント:*\n${{ github.event.comment.body || github.event.review.body }}"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
## Summary
- PR #208 のマージコンフリクト（stock-list-tab.tsx）を解消した再作成PR
- PR作成時・PRコメント時にSlack通知を送信するGitHub Actionsワークフローを追加

## 変更ファイル
- `.github/workflows/slack-notify.yml` - 新規追加

## Test plan
- [ ] PRを作成してSlack通知が届くことを確認
- [ ] PRにコメントしてSlack通知が届くことを確認

Supersedes #208

https://claude.ai/code/session_011NSQ3dT5KEytd8KEwmQEp7