### PR TITLE
feat: 商品/在庫一覧ページに商品一覧タイトルを追加

### DIFF
--- a/src/app/dashboard-page.tsx
+++ b/src/app/dashboard-page.tsx
@@ -1012,7 +1012,10 @@ export default function DashboardPage({ routeTab }: { routeTab: TabValue }) {
               </div>
             </div>
 
-            {/* テーブル */}
+            {/* 商品一覧セクション */}
+            <section className="space-y-1">
+              <h2 className="text-xl font-semibold">商品一覧</h2>
+            </section>
             {data.products.length === 0 ? (
               <p className="text-sm text-muted-foreground">まだ商品がありません。</p>
             ) : filteredProductEntries.length === 0 ? (


### PR DESCRIPTION
## 概要

商品/在庫一覧ページで、在庫一覧セクションにはタイトルがあるが商品一覧セクションにはなかった問題を修正しました。

## 変更内容

- `src/app/dashboard-page.tsx`: 商品テーブルの上に `<h2 className="text-xl font-semibold">商品一覧</h2>` を追加

## 受け入れ条件

- [x] 商品一覧セクションに「商品一覧」タイトルが表示される
- [x] 在庫一覧セクションと同様のスタイルになっている

## テスト計画

- [ ] 商品/在庫一覧タブを開き、商品テーブルの上に「商品一覧」タイトルが表示されていることを確認
- [ ] 在庫一覧セクションのタイトルと同じフォントサイズ・スタイルであることを確認

closes #212

https://claude.ai/code/session_016TMiVeCCGx26tXq3agjx1W