### PR TITLE
fix: マスタ一覧の編集・コピーボタンをアイコンボタンに統一 (#211)

### DIFF
--- a/src/app/_components/master/sections/category/category-list-section.tsx
+++ b/src/app/_components/master/sections/category/category-list-section.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react"
 
+import { Copy, Edit3 } from "lucide-react"
+
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import {
@@ -323,20 +325,25 @@ export function CategoryListSection({ data, actions, createTempId }: CategoryLis
                           {isEditing ? (
                             renderActionButtons(handleLargeSave, resetLarge, handleLargeDelete)
                           ) : (
-                            <div className="flex justify-end gap-2">
-                              <Button
+                            <div className="master-row-actions flex items-center justify-end gap-1">
+                              <button
                                 type="button"
-                                size="sm"
-                                variant="outline"
+                                className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
                                 onClick={() =>
                                   setEditingLarge({ id: category.id, name: category.name, description: category.description ?? "" })
                                 }
+                                title="編集"
                               >
-                                編集
-                              </Button>
-                              <Button type="button" size="sm" variant="secondary" onClick={() => handleLargeCopy(category)}>
-                                コピー
-                              </Button>
+                                <Edit3 className="h-4 w-4" />
+                              </button>
+                              <button
+                                type="button"
+                                className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                                onClick={() => handleLargeCopy(category)}
+                                title="コピー"
+                              >
+                                <Copy className="h-4 w-4" />
+                              </button>
                             </div>
                           )}
                         </TableCell>
@@ -417,11 +424,10 @@ export function CategoryListSection({ data, actions, createTempId }: CategoryLis
                           {isEditing ? (
                             renderActionButtons(handleMediumSave, resetMedium, handleMediumDelete)
                           ) : (
-                            <div className="flex justify-end gap-2">
-                              <Button
+                            <div className="master-row-actions flex items-center justify-end gap-1">
+                              <button
                                 type="button"
-                                size="sm"
-                                variant="outline"
+                                className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
                                 onClick={() =>
                                   setEditingMedium({
                                     id: category.id,
@@ -430,12 +436,18 @@ export function CategoryListSection({ data, actions, createTempId }: CategoryLis
                                     largeId: category.largeId,
                                   })
                                 }
+                                title="編集"
                               >
-                                編集
-                              </Button>
-                              <Button type="button" size="sm" variant="secondary" onClick={() => handleMediumCopy(category)}>
-                                コピー
-                              </Button>
+                                <Edit3 className="h-4 w-4" />
+                              </button>
+                              <button
+                                type="button"
+                                className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                                onClick={() => handleMediumCopy(category)}
+                                title="コピー"
+                              >
+                                <Copy className="h-4 w-4" />
+                              </button>
                             </div>
                           )}
                         </TableCell>
@@ -516,11 +528,10 @@ export function CategoryListSection({ data, actions, createTempId }: CategoryLis
                           {isEditing ? (
                             renderActionButtons(handleSmallSave, resetSmall, handleSmallDelete)
                           ) : (
-                            <div className="flex justify-end gap-2">
-                              <Button
+                            <div className="master-row-actions flex items-center justify-end gap-1">
+                              <button
                                 type="button"
-                                size="sm"
-                                variant="outline"
+                                className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
                                 onClick={() =>
                                   setEditingSmall({
                                     id: category.id,
@@ -529,12 +540,18 @@ export function CategoryListSection({ data, actions, createTempId }: CategoryLis
                                     mediumId: category.mediumId,
                                   })
                                 }
+                                title="編集"
                               >
-                                編集
-                              </Button>
-                              <Button type="button" size="sm" variant="secondary" onClick={() => handleSmallCopy(category)}>
-                                コピー
-                              </Button>
+                                <Edit3 className="h-4 w-4" />
+                              </button>
+                              <button
+                                type="button"
+                                className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                                onClick={() => handleSmallCopy(category)}
+                                title="コピー"
+                              >
+                                <Copy className="h-4 w-4" />
+                              </button>
                             </div>
                           )}
                         </TableCell>

--- a/src/app/_components/master/sections/equipment/equipment-list-section.tsx
+++ b/src/app/_components/master/sections/equipment/equipment-list-section.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react"
 
+import { Copy, Edit3 } from "lucide-react"
+
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -216,11 +218,10 @@ export function EquipmentListSection({ data, actions, createTempId }: EquipmentL
                         {isEditing ? (
                           renderActionButtons(handleEquipmentSave, resetEquipment, handleEquipmentDelete)
                         ) : (
-                          <div className="flex justify-end gap-2">
-                            <Button
+                          <div className="master-row-actions flex items-center justify-end gap-1">
+                            <button
                               type="button"
-                              size="sm"
-                              variant="outline"
+                              className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
                               onClick={() =>
                                 setEditingEquipment({
                                   id: equipment.id,
@@ -232,12 +233,18 @@ export function EquipmentListSection({ data, actions, createTempId }: EquipmentL
                                   note: equipment.note ?? "",
                                 })
                               }
+                              title="編集"
                             >
-                              編集
-                            </Button>
-                            <Button type="button" size="sm" variant="secondary" onClick={() => handleEquipmentCopy(equipment)}>
-                              コピー
-                            </Button>
+                              <Edit3 className="h-4 w-4" />
+                            </button>
+                            <button
+                              type="button"
+                              className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                              onClick={() => handleEquipmentCopy(equipment)}
+                              title="コピー"
+                            >
+                              <Copy className="h-4 w-4" />
+                            </button>
                           </div>
                         )}
                       </TableCell>

--- a/src/app/_components/master/sections/fee/fee-list-section.tsx
+++ b/src/app/_components/master/sections/fee/fee-list-section.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react"
 
+import { Copy, Edit3 } from "lucide-react"
+
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -187,11 +189,10 @@ export function FeeListSection({ data, actions, createTempId }: FeeListSectionPr
                         {isEditing
                           ? renderActions(handleSave, reset, handleDelete)
                           : (
-                            <div className="flex justify-end gap-2">
-                              <Button
+                            <div className="master-row-actions flex items-center justify-end gap-1">
+                              <button
                                 type="button"
-                                size="sm"
-                                variant="outline"
+                                className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
                                 onClick={() =>
                                   setEditingFee({
                                     id: fee.id,
@@ -202,12 +203,18 @@ export function FeeListSection({ data, actions, createTempId }: FeeListSectionPr
                                     note: fee.note ?? "",
                                   })
                                 }
+                                title="編集"
                               >
-                                編集
-                              </Button>
-                              <Button type="button" size="sm" variant="ghost" onClick={() => handleCopy(fee)}>
-                                複製
-                              </Button>
+                                <Edit3 className="h-4 w-4" />
+                              </button>
+                              <button
+                                type="button"
+                                className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                                onClick={() => handleCopy(fee)}
+                                title="複製"
+                              >
+                                <Copy className="h-4 w-4" />
+                              </button>
                             </div>
                             )}
                       </TableCell>

--- a/src/app/_components/master/sections/labor/labor-list-section.tsx
+++ b/src/app/_components/master/sections/labor/labor-list-section.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react"
 
+import { Copy, Edit3 } from "lucide-react"
+
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -156,11 +158,10 @@ export function LaborListSection({ data, actions, createTempId }: LaborListSecti
                         {isEditing ? (
                           renderActionButtons(handleLaborSave, resetLabor, handleLaborDelete)
                         ) : (
-                          <div className="flex justify-end gap-2">
-                            <Button
+                          <div className="master-row-actions flex items-center justify-end gap-1">
+                            <button
                               type="button"
-                              size="sm"
-                              variant="outline"
+                              className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
                               onClick={() =>
                                 setEditingLabor({
                                   id: role.id,
@@ -170,12 +171,18 @@ export function LaborListSection({ data, actions, createTempId }: LaborListSecti
                                   note: role.note ?? "",
                                 })
                               }
+                              title="編集"
                             >
-                              編集
-                            </Button>
-                            <Button type="button" size="sm" variant="secondary" onClick={() => handleLaborCopy(role)}>
-                              コピー
-                            </Button>
+                              <Edit3 className="h-4 w-4" />
+                            </button>
+                            <button
+                              type="button"
+                              className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                              onClick={() => handleLaborCopy(role)}
+                              title="コピー"
+                            >
+                              <Copy className="h-4 w-4" />
+                            </button>
                           </div>
                         )}
                       </TableCell>

--- a/src/app/_components/master/sections/material/material-list-section.tsx
+++ b/src/app/_components/master/sections/material/material-list-section.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react"
 
+import { Copy, Edit3 } from "lucide-react"
+
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -444,11 +446,10 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
                         {isEditing ? (
                           renderActionButtons(handleMaterialSave, resetMaterial, handleMaterialDelete)
                         ) : (
-                          <div className="master-row-actions flex justify-end gap-2">
-                            <Button
+                          <div className="master-row-actions flex items-center justify-end gap-1">
+                            <button
                               type="button"
-                              size="sm"
-                              variant="outline"
+                              className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
                               onClick={() => {
                                 setEditingStock(null)
                                 setEditingMaterial({
@@ -463,12 +464,18 @@ export function MaterialListSection({ data, actions, createTempId, isAuthenticat
                                   note: material.note ?? "",
                                 })
                               }}
+                              title="編集"
                             >
-                              編集
-                            </Button>
-                            <Button type="button" size="sm" variant="secondary" onClick={() => handleMaterialCopy(material)}>
-                              コピー
-                            </Button>
+                              <Edit3 className="h-4 w-4" />
+                            </button>
+                            <button
+                              type="button"
+                              className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                              onClick={() => handleMaterialCopy(material)}
+                              title="コピー"
+                            >
+                              <Copy className="h-4 w-4" />
+                            </button>
                           </div>
                         )}
                       </TableCell>

--- a/src/app/_components/master/sections/option-preset/option-preset-list-section.tsx
+++ b/src/app/_components/master/sections/option-preset/option-preset-list-section.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react"
 
+import { Copy, Edit3 } from "lucide-react"
+
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -176,11 +178,10 @@ export function OptionPresetListSection({ data, actions, createTempId }: OptionP
                             <Button type="button" size="sm" variant="ghost" onClick={resetOptionPreset}>キャンセル</Button>
                           </div>
                         ) : (
-                          <div className="flex justify-end gap-2">
-                            <Button
+                          <div className="master-row-actions flex items-center justify-end gap-1">
+                            <button
                               type="button"
-                              size="sm"
-                              variant="outline"
+                              className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
                               onClick={() =>
                                 setEditingOptionPreset({
                                   id: preset.id,
@@ -191,12 +192,18 @@ export function OptionPresetListSection({ data, actions, createTempId }: OptionP
                                       : [{ label: "", quantity: 0 }],
                                 })
                               }
+                              title="編集"
                             >
-                              編集
-                            </Button>
-                            <Button type="button" size="sm" variant="secondary" onClick={() => handlePresetCopy(preset)}>
-                              コピー
-                            </Button>
+                              <Edit3 className="h-4 w-4" />
+                            </button>
+                            <button
+                              type="button"
+                              className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                              onClick={() => handlePresetCopy(preset)}
+                              title="コピー"
+                            >
+                              <Copy className="h-4 w-4" />
+                            </button>
                           </div>
                         )}
                       </TableCell>

--- a/src/app/_components/master/sections/packaging/packaging-list-section.tsx
+++ b/src/app/_components/master/sections/packaging/packaging-list-section.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react"
 
+import { Copy, Edit3 } from "lucide-react"
+
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -417,11 +419,10 @@ export function PackagingListSection({ data, actions, createTempId, isAuthentica
                         {isEditing ? (
                           renderActionButtons(handlePackagingSave, resetPackaging, handlePackagingDelete)
                         ) : (
-                          <div className="master-row-actions flex justify-end gap-2">
-                            <Button
+                          <div className="master-row-actions flex items-center justify-end gap-1">
+                            <button
                               type="button"
-                              size="sm"
-                              variant="outline"
+                              className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
                               onClick={() => {
                                 setEditingStock(null)
                                 setEditingPackaging({
@@ -435,12 +436,18 @@ export function PackagingListSection({ data, actions, createTempId, isAuthentica
                                   note: item.note ?? "",
                                 })
                               }}
+                              title="編集"
                             >
-                              編集
-                            </Button>
-                            <Button type="button" size="sm" variant="secondary" onClick={() => handlePackagingCopy(item)}>
-                              コピー
-                            </Button>
+                              <Edit3 className="h-4 w-4" />
+                            </button>
+                            <button
+                              type="button"
+                              className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                              onClick={() => handlePackagingCopy(item)}
+                              title="コピー"
+                            >
+                              <Copy className="h-4 w-4" />
+                            </button>
                           </div>
                         )}
                       </TableCell>

--- a/src/app/_components/master/sections/shipping/shipping-list-section.tsx
+++ b/src/app/_components/master/sections/shipping/shipping-list-section.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react"
 
+import { Copy, Edit3 } from "lucide-react"
+
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -183,11 +185,10 @@ export function ShippingListSection({ data, actions, createTempId }: ShippingLis
                         {isEditing ? (
                           renderActionButtons(handleShippingSave, resetShipping, handleShippingDelete)
                         ) : (
-                          <div className="flex justify-end gap-2">
-                            <Button
+                          <div className="master-row-actions flex items-center justify-end gap-1">
+                            <button
                               type="button"
-                              size="sm"
-                              variant="outline"
+                              className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
                               onClick={() =>
                                 setEditingShipping({
                                   id: method.id,
@@ -198,12 +199,18 @@ export function ShippingListSection({ data, actions, createTempId }: ShippingLis
                                   note: method.note ?? "",
                                 })
                               }
+                              title="編集"
                             >
-                              編集
-                            </Button>
-                            <Button type="button" size="sm" variant="secondary" onClick={() => handleShippingCopy(method)}>
-                              コピー
-                            </Button>
+                              <Edit3 className="h-4 w-4" />
+                            </button>
+                            <button
+                              type="button"
+                              className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                              onClick={() => handleShippingCopy(method)}
+                              title="コピー"
+                            >
+                              <Copy className="h-4 w-4" />
+                            </button>
                           </div>
                         )}
                       </TableCell>


### PR DESCRIPTION
## Summary

- 全マスタセクション8ファイルのテキストボタン（"編集"/"コピー"）をアイコンボタン（Edit3/Copy）に変更
- 商品一覧（customizable-product-table.tsx）と同じホバー時表示パターンに統一
- `master-row-actions` クラスにより、デスクトップではホバー時のみアイコン表示、モバイルでは常に表示

## 変更ファイル一覧

| ファイル | 変更内容 |
|---------|--------|
| category-list-section.tsx | 大・中・小カテゴリの編集/コピーをアイコンに変更 |
| material-list-section.tsx | 材料の編集/コピーをアイコンに変更 |
| packaging-list-section.tsx | 梱包材の編集/コピーをアイコンに変更 |
| option-preset-list-section.tsx | オプションの編集/コピーをアイコンに変更 |
| shipping-list-section.tsx | 配送の編集/コピーをアイコンに変更 |
| fee-list-section.tsx | 手数料の編集/複製をアイコンに変更 |
| labor-list-section.tsx | 人件費の編集/コピーをアイコンに変更 |
| equipment-list-section.tsx | 設備の編集/コピーをアイコンに変更 |

## 受け入れ条件の検証

- [x] 全ページの編集・削除ボタンを調査し、一覧化
- [x] 統一されていない箇所を修正（全8マスタセクション）
- [x] 全ページで同じUIパターン（ホバー時アイコン表示）が適用されている

## Test plan

- [ ] 各マスタセクションでホバー時に編集・コピーアイコンが表示されることを確認
- [ ] 各アイコンクリックで編集モード/コピー操作が正常に動作することを確認
- [ ] モバイル表示でアイコンが常に表示されることを確認
- [ ] 商品一覧と見た目が統一されていることを確認

Closes #211

https://claude.ai/code/session_01Nv8ZjHkwDzvf7mRWXNEtuX