### PR TITLE
fix: iOS Safariでカードごと横スクロールされる問題を修正

### DIFF
--- a/src/app/_components/audit/audit-tab.tsx
+++ b/src/app/_components/audit/audit-tab.tsx
@@ -127,7 +127,7 @@ export function AuditTab({ logs, loading, onRefresh, onLoadMore, hasMore, filter
   }
 
   return (
-    <div className="space-y-4 overflow-hidden">
+    <div className="min-w-0 space-y-4 overflow-hidden">
       {/* ページヘッダー */}
       <div>
         <h1 className="text-2xl font-semibold">監査ログ</h1>

--- a/src/app/_components/cost/cost-tab.tsx
+++ b/src/app/_components/cost/cost-tab.tsx
@@ -126,52 +126,52 @@ export function CostTab({ data }: CostTabProps) {
         </div>
       </div>
 
-      <div className="cost-section-block space-y-3 overflow-hidden">
+      <div className="cost-section-block min-w-0 space-y-3 overflow-hidden">
         {renderSectionToggle("summary", "原価サマリ")}
         {openState.summary && <CostSummarySection data={data} />}
       </div>
 
-      <div className="cost-section-block space-y-3 overflow-hidden">
+      <div className="cost-section-block min-w-0 space-y-3 overflow-hidden">
         {renderSectionToggle("profitSimulation", "利益シミュレーション")}
         {openState.profitSimulation && <ProfitSimulationSection data={data} />}
       </div>
 
-      <div className="cost-section-block space-y-3 overflow-hidden">
+      <div className="cost-section-block min-w-0 space-y-3 overflow-hidden">
         {renderSectionToggle("packaging", "梱包コスト集計")}
         {openState.packaging && <PackagingCostSection data={data} />}
       </div>
 
-      <div className="cost-section-block space-y-3 overflow-hidden">
+      <div className="cost-section-block min-w-0 space-y-3 overflow-hidden">
         {renderSectionToggle("labor", "人件費")}
         {openState.labor && <LaborCostSection data={data} />}
       </div>
 
-      <div className="cost-section-block space-y-3 overflow-hidden">
+      <div className="cost-section-block min-w-0 space-y-3 overflow-hidden">
         {renderSectionToggle("outsourcing", "外注費")}
         {openState.outsourcing && <OutsourcingCostSection data={data} />}
       </div>
 
-      <div className="cost-section-block space-y-3 overflow-hidden">
+      <div className="cost-section-block min-w-0 space-y-3 overflow-hidden">
         {renderSectionToggle("development", "開発コスト")}
         {openState.development && <DevelopmentCostSection data={data} />}
       </div>
 
-      <div className="cost-section-block space-y-3 overflow-hidden">
+      <div className="cost-section-block min-w-0 space-y-3 overflow-hidden">
         {renderSectionToggle("equipment", "設備配賦")}
         {openState.equipment && <EquipmentAllocationSection data={data} />}
       </div>
 
-      <div className="cost-section-block space-y-3 overflow-hidden">
+      <div className="cost-section-block min-w-0 space-y-3 overflow-hidden">
         {renderSectionToggle("logistics", "物流・配送費")}
         {openState.logistics && <LogisticsCostSection data={data} />}
       </div>
 
-      <div className="cost-section-block space-y-3 overflow-hidden">
+      <div className="cost-section-block min-w-0 space-y-3 overflow-hidden">
         {renderSectionToggle("electricity", "電気代")}
         {openState.electricity && <ElectricityCostSection data={data} />}
       </div>
 
-      <div className="cost-section-block space-y-3 overflow-hidden">
+      <div className="cost-section-block min-w-0 space-y-3 overflow-hidden">
         {renderSectionToggle("fees", "販売・決済手数料")}
         {openState.fees && <FeesCostSection data={data} />}
       </div>

--- a/src/app/_components/cost/sections/cost-summary-section.tsx
+++ b/src/app/_components/cost/sections/cost-summary-section.tsx
@@ -69,7 +69,7 @@ export function CostSummarySection({ data }: CostSummarySectionProps) {
   }
 
   return (
-    <section className="space-y-3">
+    <section className="min-w-0 space-y-3">
       <div>
         <h2 className="text-xl font-semibold">原価サマリ</h2>
         <p className="text-sm text-muted-foreground">カテゴリ別の積み上げと合計を確認できます。</p>

--- a/src/app/_components/cost/sections/equipment-allocation-section.tsx
+++ b/src/app/_components/cost/sections/equipment-allocation-section.tsx
@@ -58,7 +58,7 @@ export function EquipmentAllocationSection({ data }: CostSectionProps) {
   }, [data.costEntries.equipmentAllocations, data.equipments, data.products])
 
   return (
-    <section className="space-y-3 rounded-lg border p-4">
+    <section className="min-w-0 space-y-3 rounded-lg border p-4">
       <div>
         <h2 className="text-xl font-semibold">設備配賦</h2>
         <p className="text-sm text-muted-foreground">設備単位での配賦状況</p>

--- a/src/app/_components/cost/sections/packaging-cost-section.tsx
+++ b/src/app/_components/cost/sections/packaging-cost-section.tsx
@@ -167,8 +167,8 @@ export function PackagingCostSection({ data }: PackagingCostSectionProps) {
   )
 
   return (
-    <div className="space-y-4">
-      <section className="space-y-3 rounded-lg border p-4">
+    <div className="min-w-0 space-y-4">
+      <section className="min-w-0 space-y-3 rounded-lg border p-4">
         {renderSectionToggle(
           packagingDetailOpen,
           () => setPackagingDetailOpen((prev) => !prev),
@@ -250,7 +250,7 @@ export function PackagingCostSection({ data }: PackagingCostSectionProps) {
         )}
       </section>
 
-      <section className="space-y-3 rounded-lg border p-4">
+      <section className="min-w-0 space-y-3 rounded-lg border p-4">
         {renderSectionToggle(
           packagingSummaryOpen,
           () => setPackagingSummaryOpen((prev) => !prev),

--- a/src/app/_components/cost/sections/profit-simulation-section.tsx
+++ b/src/app/_components/cost/sections/profit-simulation-section.tsx
@@ -46,7 +46,7 @@ export function ProfitSimulationSection({ data }: ProfitSimulationSectionProps) 
   }
 
   return (
-    <section className="space-y-3 rounded-lg border p-4">
+    <section className="min-w-0 space-y-3 rounded-lg border p-4">
       <div>
         <h2 className="text-xl font-semibold">目標利益率シミュレーション</h2>
         <p className="text-sm text-muted-foreground">目標利益率と販売数量を入力し、必要な販売価格と粗利を逆算します。</p>

--- a/src/app/_components/master/list/master-list-view.tsx
+++ b/src/app/_components/master/list/master-list-view.tsx
@@ -124,7 +124,7 @@ export function MasterListView({ data, actions, isAuthenticated, materialStocks,
   )
 
   return (
-    <div className="master-list-table-style space-y-6 overflow-x-hidden">
+    <div className="master-list-table-style min-w-0 space-y-6 overflow-x-hidden">
       <div className="flex justify-end gap-2">
         <Button type="button" size="sm" variant="outline" onClick={() => setAllOpenState(true)}>
           全て開く
@@ -134,13 +134,13 @@ export function MasterListView({ data, actions, isAuthenticated, materialStocks,
         </Button>
       </div>
 
-      <div className="space-y-2 overflow-hidden">
+      <div className="min-w-0 space-y-2 overflow-hidden">
         {renderSectionToggle("category", "カテゴリ一覧")}
         {openState.category && <CategoryListSection data={data} actions={actions} createTempId={createTempId} />}
       </div>
 
       <div className="space-y-6">
-        <div className="space-y-2 overflow-hidden">
+        <div className="min-w-0 space-y-2 overflow-hidden">
           {renderSectionToggle("material", "材料一覧")}
           {openState.material && (
             <MaterialListSection
@@ -157,7 +157,7 @@ export function MasterListView({ data, actions, isAuthenticated, materialStocks,
           )}
         </div>
 
-        <div className="space-y-2 overflow-hidden">
+        <div className="min-w-0 space-y-2 overflow-hidden">
           {renderSectionToggle("packaging", "梱包材一覧")}
           {openState.packaging && (
             <PackagingListSection
@@ -174,29 +174,29 @@ export function MasterListView({ data, actions, isAuthenticated, materialStocks,
           )}
         </div>
 
-        <div className="space-y-2 overflow-hidden">
+        <div className="min-w-0 space-y-2 overflow-hidden">
           {renderSectionToggle("optionPreset", "オプション一覧")}
           {openState.optionPreset && <OptionPresetListSection data={data} actions={actions} createTempId={createTempId} />}
         </div>
       </div>
 
       <div className="space-y-6">
-        <div className="space-y-2 overflow-hidden">
+        <div className="min-w-0 space-y-2 overflow-hidden">
           {renderSectionToggle("shipping", "配送一覧")}
           {openState.shipping && <ShippingListSection data={data} actions={actions} createTempId={createTempId} />}
         </div>
 
-        <div className="space-y-2 overflow-hidden">
+        <div className="min-w-0 space-y-2 overflow-hidden">
           {renderSectionToggle("fee", "手数料一覧")}
           {openState.fee && <FeeListSection data={data} actions={actions} createTempId={createTempId} />}
         </div>
 
-        <div className="space-y-2 overflow-hidden">
+        <div className="min-w-0 space-y-2 overflow-hidden">
           {renderSectionToggle("labor", "人件費一覧")}
           {openState.labor && <LaborListSection data={data} actions={actions} createTempId={createTempId} />}
         </div>
 
-        <div className="space-y-2 overflow-hidden">
+        <div className="min-w-0 space-y-2 overflow-hidden">
           {renderSectionToggle("equipment", "設備一覧")}
           {openState.equipment && <EquipmentListSection data={data} actions={actions} createTempId={createTempId} />}
         </div>

--- a/src/app/_components/product-list/customizable-product-table.tsx
+++ b/src/app/_components/product-list/customizable-product-table.tsx
@@ -250,7 +250,7 @@ export function CustomizableProductTable({
   }
 
   return (
-    <div className="space-y-3 overflow-hidden">
+    <div className="min-w-0 space-y-3 overflow-hidden">
       <div className="flex flex-col gap-2 rounded-md border border-dashed p-3 md:flex-row md:items-center md:justify-between">
         <p className="text-xs text-muted-foreground">
           {isAuthenticated

--- a/src/app/_components/shared/ui.tsx
+++ b/src/app/_components/shared/ui.tsx
@@ -200,7 +200,7 @@ export function CostDisplay({
   }
 
   return (
-    <section className="space-y-3 rounded-lg border p-4">
+    <section className="min-w-0 space-y-3 rounded-lg border p-4">
       <div>
         <h2 className="text-xl font-semibold">{title}</h2>
         <p className="text-sm text-muted-foreground">{description}</p>

--- a/src/app/_components/stock-list/stock-list-tab.tsx
+++ b/src/app/_components/stock-list/stock-list-tab.tsx
@@ -132,7 +132,7 @@ export function StockListTab({
         <p className="text-sm text-muted-foreground">材料・梱包材・設備の在庫情報を確認できます。</p>
       </section>
 
-      <section className="space-y-3 overflow-hidden">
+      <section className="min-w-0 space-y-3 overflow-hidden">
         <h3 className="text-lg font-semibold">材料在庫</h3>
         {!isAuthenticated ? (
           <p className="text-sm text-muted-foreground">在庫表示はログイン中のみ利用できます。</p>
@@ -223,7 +223,7 @@ export function StockListTab({
         )}
       </section>
 
-      <section className="space-y-3 overflow-hidden">
+      <section className="min-w-0 space-y-3 overflow-hidden">
         <h3 className="text-lg font-semibold">梱包材在庫</h3>
         {!isAuthenticated ? (
           <p className="text-sm text-muted-foreground">在庫表示はログイン中のみ利用できます。</p>
@@ -312,7 +312,7 @@ export function StockListTab({
         )}
       </section>
 
-      <section className="space-y-3 overflow-hidden">
+      <section className="min-w-0 space-y-3 overflow-hidden">
         <h3 className="text-lg font-semibold">設備一覧</h3>
         {data.equipments.length === 0 ? (
           <p className="text-sm text-muted-foreground">設備が登録されていません。</p>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -65,7 +65,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-content"
-      className={cn("px-6", className)}
+      className={cn("px-6 min-w-0", className)}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- CardContent(card.tsx)およびテーブルを含む全コンポーネントに `min-w-0` を追加
- iOS Safari/WebKitではflex子要素のデフォルト `min-width: auto` によりテーブルの `min-w-[980px]` 等がカード全体を押し広げていた
- 対象ページ: 原価サマリ、マスタ一覧、在庫一覧、商品一覧、監査ログ（全11ファイル）

## 原因
- Card は `flex flex-col` だが、CardContent には `min-w-0` がなかった
- ブロック要素に `overflow-hidden` を付けても、iOS Safari の flex コンテキストでは子要素が親を押し広げることがある
- ログイン時（テーブルにデータがある状態）のみ発生していたのは、テーブルの `min-width` 指定がデータ有り時にのみ効くため

## Test plan
- [ ] iPhone 12 Pro Safari でログイン状態の各ページを確認
- [ ] iPhone 12 Pro Google アプリでログイン状態の各ページを確認
- [ ] 原価サマリ: テーブル内のみスクロール、カード固定
- [ ] マスタ一覧（材料・梱包材・設備等）: テーブル内のみスクロール、カード固定
- [ ] 在庫一覧: テーブル内のみスクロール、カード固定
- [ ] 商品一覧: テーブル内のみスクロール、カード固定
- [ ] 監査ログ: テーブル内のみスクロール、カード固定
- [ ] PC ブラウザでの表示に影響がないこと

https://claude.ai/code/session_01PcZdT6XUiNs6DE9DMSyqYP